### PR TITLE
Create default.html with SAP-compliant footer

### DIFF
--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -23,7 +23,10 @@
           <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html">Terms of Use</a>.
           <a href="{{ site.github.repository_url }}/blob/main/{{ page.path }}">View On <strong>GitHub</strong></a>.
         </p>
-        <p>This site is hosted by GitHub Pages. Please see the GitHub Privacy Statement for any information how GitHub processes your personal data. </p>  
+        <p>
+          This site is hosted by <a href="https://pages.github.com/">GitHub Pages</a>. 
+          Please see the <a href="https://docs.github.com/en/github/site-policy/github-privacy-statement">GitHub Privacy Statement</a> for any information how GitHub processes your personal data.
+        </p> 
       </div>
     </footer>
   </body>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -19,6 +19,7 @@
       <div class="container">
         <p>
           © Copyright 2017, SAP SE and odata-vocabularies Contributors.
+          <a href="https://www.sap.com/about/legal/impressum.html">Legal Disclosure</a>.
           <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html">Terms of Use</a>.
           <a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a>.
         </p>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -18,7 +18,7 @@
     <footer>
       <div class="container">
         <p>
-          © Copyright 2017, SAP SE and odata-vocabularies Contributors.
+          © Copyright 2016, SAP SE and odata-vocabularies Contributors.
           <a href="https://www.sap.com/about/legal/impressum.html">Legal Disclosure</a>.
           <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html">Terms of Use</a>.
           <a href="{{ site.github.repository_url }}/blob/main/{{ page.path }}">View On <strong>GitHub</strong></a>.

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -21,7 +21,7 @@
           © Copyright 2017, SAP SE and odata-vocabularies Contributors.
           <a href="https://www.sap.com/about/legal/impressum.html">Legal Disclosure</a>.
           <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html">Terms of Use</a>.
-          <a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a>.
+          <a href="{{ site.github.repository_url }}/blob/main/{{ page.path }}">View On <strong>GitHub</strong></a>.
         </p>
         <p>This site is hosted by GitHub Pages. Please see the GitHub Privacy Statement for any information how GitHub processes your personal data. </p>  
       </div>

--- a/_layouts/default.html
+++ b/_layouts/default.html
@@ -1,0 +1,29 @@
+<!DOCTYPE html>
+<html lang="{{ site.lang | default: "en-US" }}">
+  <head>
+    <meta charset="UTF-8">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+
+{% seo %}
+    <link rel="stylesheet" href="{{ "/assets/css/style.css?v=" | append: site.github.build_revision | relative_url }}">
+  </head>
+  <body>
+    <div class="container-lg px-3 my-5 markdown-body">
+      <h1><a href="{{ "/" | absolute_url }}">{{ site.title | default: site.github.repository_name }}</a></h1>
+
+      {{ content }}
+      
+    </div>
+    <footer>
+      <div class="container">
+        <p>
+          © Copyright 2017, SAP SE and odata-vocabularies Contributors.
+          <a href="https://www.sap.com/corporate/en/legal/terms-of-use.html">Terms of Use</a>.
+          <a href="{{ site.github.repository_url }}">View On <strong>GitHub</strong></a>.
+        </p>
+        <p>This site is hosted by GitHub Pages. Please see the GitHub Privacy Statement for any information how GitHub processes your personal data. </p>  
+      </div>
+    </footer>
+  </body>
+</html>


### PR DESCRIPTION
Jekyll default page layout.

Sources of information:
- https://github.com/pages-themes/minimal/blob/master/_layouts/default.html
- https://jekyllrb.com/docs/variables/

Tried it out on https://ralfhandl.github.io/odata-vocabularies/vocabularies/HTML5.html