### PR TITLE
SemanticObject applies to NavigationProperties

### DIFF
--- a/vocabularies/Common.json
+++ b/vocabularies/Common.json
@@ -319,7 +319,8 @@
             "$AppliesTo": [
                 "EntitySet",
                 "EntityType",
-                "Property"
+                "Property",
+                "NavigationProperty"
             ],
             "@Core.Description": "Name of the Semantic Object represented as this entity type or identified by this property"
         },

--- a/vocabularies/Common.xml
+++ b/vocabularies/Common.xml
@@ -263,7 +263,7 @@
         <Annotation Term="Core.Description" String="Unmasked data for this property can be requested with custom query option `masked-values=false`" />
       </Term>
 
-      <Term Name="SemanticObject" Type="Edm.String" Nullable="true" AppliesTo="EntitySet EntityType Property">
+      <Term Name="SemanticObject" Type="Edm.String" Nullable="true" AppliesTo="EntitySet EntityType Property NavigationProperty">
         <Annotation Term="Core.Description" String="Name of the Semantic Object represented as this entity type or identified by this property" />
       </Term>
       <Term Name="SemanticObjectMapping" BaseTerm="Common.SemanticObject" Type="Collection(Common.SemanticObjectMappingType)" Nullable="false" AppliesTo="EntitySet EntityType Property">


### PR DESCRIPTION
Common.Semantic annotation could also be applied to NavigationProperties (as the foreign keys might not be provided, e.g. by using cds.odata.refs flavor)