### PR TITLE
Changing type of Margin, Border, FitToPage, FontSize, & FontName

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ This repository defines the following SAP vocabularies:
 - [Hierarchy: Hierarchies](vocabularies/Hierarchy.md) - _experimental_
 - [HTML5: Rendering directives for UI5](vocabularies/HTML5.md)
 - [ODM: One Domain Model](vocabularies/ODM.md) - _experimental_
+- [PDF: PDF response format](vocabularies/PDF.md) - _experimental_
 - [PersonalData: Personal data / GDPR](vocabularies/PersonalData.md)
 - [Session: Sticky Sessions](vocabularies/Session.md)
 - [UI: Representing data in user interfaces](vocabularies/UI.md)

--- a/examples/PDF.Features-examples.json
+++ b/examples/PDF.Features-examples.json
@@ -1,0 +1,46 @@
+{
+    "$Version": "4.0",
+    "$Reference": {
+        "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+            "$Include": [
+                {
+                    "$Namespace": "Org.OData.Core.V1",
+                    "$Alias": "Core"
+                }
+            ]
+        },
+        "https://sap.github.io/odata-vocabularies/vocabularies/PDF.json": {
+            "$Include": [
+                {
+                    "$Namespace": "com.sap.vocabularies.PDF.v1",
+                    "$Alias": "PDF"
+                }
+            ]
+        }
+    },
+    "PDF.examples": {
+        "Container": {
+            "$Kind": "EntityContainer",
+            "@Core.Description": "Imagine some entity sets here"
+        },
+        "$Annotations": {
+            "PDF.examples/Container": {
+                "@PDF.Features": {
+                    "DocumentDescriptionReference": "../../../../default/iwbep/common/0001/$metadata",
+                    "DocumentDescriptionCollection": "MyDocumentDescriptions",
+                    "ArchiveFormat": true,
+                    "Signature": true,
+                    "CoverPage": true,
+                    "FontSize": 12,
+                    "FontName": "Arial",
+                    "Margin": 3,
+                    "Border": 1,
+                    "FitToPage": false,
+                    "ResultSizeDefault": 5000,
+                    "ResultSizeMaximum": 50000
+                }
+            }
+        }
+    },
+    "$EntityContainer": "PDF.examples.Container"
+}

--- a/examples/PDF.Features-examples.xml
+++ b/examples/PDF.Features-examples.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+  </edmx:Reference>
+
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/PDF.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.PDF.v1" Alias="PDF" />
+  </edmx:Reference>
+  <edmx:DataServices>
+    <Schema Namespace="PDF.examples" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+
+      <EntityContainer Name="Container">
+        <Annotation Term="Core.Description" String="Imagine some entity sets here" />
+      </EntityContainer>
+
+      <Annotations Target="PDF.examples/Container">
+        <Annotation Term="PDF.Features">
+          <Record>
+            <PropertyValue Property="DocumentDescriptionReference" String="../../../../default/iwbep/common/0001/$metadata" />
+            <PropertyValue Property="DocumentDescriptionCollection" String="MyDocumentDescriptions" />
+            <PropertyValue Property="ArchiveFormat" Bool="true" />
+            <PropertyValue Property="Signature" Bool="true" />
+            <PropertyValue Property="CoverPage" Bool="true" />
+            <PropertyValue Property="FontSize" Int="12" />
+            <PropertyValue Property="FontName" String="Arial" />
+            <PropertyValue Property="Margin" Int="3" />
+            <PropertyValue Property="Border" Int="1" />
+            <PropertyValue Property="FitToPage" Bool="false" />
+            <PropertyValue Property="ResultSizeDefault" Int="5000" />
+            <PropertyValue Property="ResultSizeMaximum" Int="50000" />
+          </Record>
+        </Annotation>
+      </Annotations>
+
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
   ],
   "dependencies": {
     "colors": "^1.4.0",
-    "odata-csdl": "^0.4.0",
+    "odata-csdl": "^0.4.3",
     "odata-vocabularies": "github:oasis-tcs/odata-vocabularies"
   },
   "devDependencies": {

--- a/vocabularies/PDF.json
+++ b/vocabularies/PDF.json
@@ -1,0 +1,118 @@
+{
+    "$Version": "4.0",
+    "$Reference": {
+        "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+            "$Include": [
+                {
+                    "$Namespace": "Org.OData.Core.V1",
+                    "$Alias": "Core"
+                }
+            ]
+        },
+        "https://sap.github.io/odata-vocabularies/vocabularies/Common.json": {
+            "$Include": [
+                {
+                    "$Namespace": "com.sap.vocabularies.Common.v1",
+                    "$Alias": "Common"
+                }
+            ]
+        }
+    },
+    "com.sap.vocabularies.PDF.v1": {
+        "$Alias": "PDF",
+        "@Common.Experimental": true,
+        "@Core.Description": "Terms for PDF response format",
+        "@Core.LongDescription": "The PDF vocabulary provides information about the PDF format of a response",
+        "@Core.Description#Published": "2021-10-27 © Copyright 2021 SAP SE. All rights reserved",
+        "@Core.Links": [
+            {
+                "rel": "alternate",
+                "href": "https://sap.github.io/odata-vocabularies/vocabularies/PDF.xml"
+            },
+            {
+                "rel": "latest-version",
+                "href": "https://sap.github.io/odata-vocabularies/vocabularies/PDF.json"
+            },
+            {
+                "rel": "describedby",
+                "href": "https://github.com/sap/odata-vocabularies/blob/main/vocabularies/PDF.md"
+            }
+        ],
+        "Features": {
+            "$Kind": "Term",
+            "$Type": "PDF.FeaturesType",
+            "$AppliesTo": [
+                "EntityContainer"
+            ],
+            "@Common.Experimental": true,
+            "@Core.Description": "Features for the PDF"
+        },
+        "FeaturesType": {
+            "$Kind": "ComplexType",
+            "@Common.Experimental": true,
+            "DocumentDescriptionReference": {
+                "@Core.IsURL": true,
+                "@Core.Description": "Reference of the Service for the DocumentDescription"
+            },
+            "DocumentDescriptionCollection": {
+                "@Core.Description": "Name of entity set containing the DocumentDescription"
+            },
+            "ArchiveFormat": {
+                "$Type": "Edm.Boolean",
+                "$Nullable": true,
+                "$DefaultValue": false,
+                "@Core.Description": "PDFA conformant format"
+            },
+            "Signature": {
+                "$Type": "Edm.Boolean",
+                "$Nullable": true,
+                "$DefaultValue": false,
+                "@Core.Description": "Signing the document"
+            },
+            "CoverPage": {
+                "$Type": "Edm.Boolean",
+                "$Nullable": true,
+                "$DefaultValue": false,
+                "@Core.Description": "Cover Page"
+            },
+            "FontName": {
+                "$Nullable": true,
+                "@Core.Description": "Font name"
+            },
+            "FontSize": {
+                "$Type": "Edm.Int16",
+                "$Nullable": true,
+                "@Core.Description": "Font size"
+            },
+            "Margin": {
+                "$Type": "Edm.Int16",
+                "$Nullable": true,
+                "@Core.Description": "Margin size"
+            },
+            "Border": {
+                "$Type": "Edm.Int16",
+                "$Nullable": true,
+                "@Core.Description": "Border size of the table"
+            },
+            "FitToPage": {
+                "$Type": "Edm.Boolean",
+                "$Nullable": true,
+                "$DefaultValue": false,
+                "@Core.Description": "Fit to page",
+                "@Core.LongDescription": "If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor."
+            },
+            "ResultSizeDefault": {
+                "$Type": "Edm.Int32",
+                "$Nullable": true,
+                "@Core.Description": "Default result size",
+                "@Core.LongDescription": " Default result size for PDF documents. Used if a the $top has not been provided."
+            },
+            "ResultSizeMaximum": {
+                "$Type": "Edm.Int32",
+                "$Nullable": true,
+                "@Core.Description": "Maximum result size",
+                "@Core.LongDescription": "Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum"
+            }
+        }
+    }
+}

--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -1,0 +1,31 @@
+# PDF Vocabulary
+**Namespace: [com.sap.vocabularies.PDF.v1](PDF.xml)**
+
+Terms for PDF response format
+
+The PDF vocabulary provides information about the PDF format of a response
+
+
+## Terms
+
+Term|Type|Description
+:---|:---|:----------
+[Features](./PDF.xml#L39:~:text=<Term%20Name="-,Features,-") *([Experimental](Common.md#Experimental))*|[FeaturesType](#FeaturesType)|<a name="Features"></a>Features for the PDF
+
+## <a name="FeaturesType"></a>[FeaturesType](./PDF.xml#L44:~:text=<ComplexType%20Name="-,FeaturesType,-") *([Experimental](Common.md#Experimental))*
+
+
+Property|Type|Description
+:-------|:---|:----------
+[DocumentDescriptionReference](./PDF.xml#L46:~:text=<ComplexType%20Name="-,FeaturesType,-")|URL|Reference of the Service for the DocumentDescription
+[DocumentDescriptionCollection](./PDF.xml#L50:~:text=<ComplexType%20Name="-,FeaturesType,-")|String|Name of entity set containing the DocumentDescription
+[ArchiveFormat](./PDF.xml#L53:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|PDFA conformant format
+[Signature](./PDF.xml#L56:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Signing the document
+[CoverPage](./PDF.xml#L59:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Cover Page
+[FontName](./PDF.xml#L62:~:text=<ComplexType%20Name="-,FeaturesType,-")|String?|Font name
+[FontSize](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Font size
+[Margin](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Margin size
+[Border](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Border size of the table
+[FitToPage](./PDF.xml#L74:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
+[ResultSizeDefault](./PDF.xml#L80:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if a the $top has not been provided.
+[ResultSizeMaximum](./PDF.xml#L86:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum

--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -20,12 +20,12 @@ Property|Type|Description
 [DocumentDescriptionReference](./PDF.xml#L46:~:text=<ComplexType%20Name="-,FeaturesType,-")|URL|Reference of the Service for the DocumentDescription
 [DocumentDescriptionCollection](./PDF.xml#L50:~:text=<ComplexType%20Name="-,FeaturesType,-")|String|Name of entity set containing the DocumentDescription
 [ArchiveFormat](./PDF.xml#L53:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|PDFA conformant format
-[Signature](./PDF.xml#L56:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Signing the document
-[CoverPage](./PDF.xml#L59:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Cover Page
-[FontName](./PDF.xml#L62:~:text=<ComplexType%20Name="-,FeaturesType,-")|String?|Font name
-[FontSize](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Font size
-[Margin](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Margin size
-[Border](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int16?|Border size of the table
-[FitToPage](./PDF.xml#L74:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean?|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
-[ResultSizeDefault](./PDF.xml#L80:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if a the $top has not been provided.
-[ResultSizeMaximum](./PDF.xml#L86:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum
+[Signature](./PDF.xml#L56:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Signing the document
+[CoverPage](./PDF.xml#L59:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Cover Page
+[FontName](./PDF.xml#L62:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font name
+[FontSize](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font size
+[Margin](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size
+[Border](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table
+[FitToPage](./PDF.xml#L74:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
+[ResultSizeDefault](./PDF.xml#L80:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32|Default result size<br>Default result size for PDF documents. Used if a the $top has not been provided.
+[ResultSizeMaximum](./PDF.xml#L86:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum

--- a/vocabularies/PDF.xml
+++ b/vocabularies/PDF.xml
@@ -1,0 +1,96 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common" />
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="com.sap.vocabularies.PDF.v1" Alias="PDF">
+      <Annotation Term="Common.Experimental" />
+      <Annotation Term="Core.Description">
+        <String>Terms for PDF response format</String>
+      </Annotation>
+      <Annotation Term="Core.LongDescription">
+        <String>The PDF vocabulary provides information about the PDF format of a response</String>
+      </Annotation>
+      <Annotation Term="Core.Description" Qualifier="Published">
+        <String>2021-10-27 © Copyright 2021 SAP SE. All rights reserved</String>
+      </Annotation>
+      <Annotation Term="Core.Links">
+        <Collection>
+          <Record>
+            <PropertyValue Property="rel" String="latest-version" />
+            <PropertyValue Property="href" String="https://sap.github.io/odata-vocabularies/vocabularies/PDF.xml" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="alternate" />
+            <PropertyValue Property="href" String="https://sap.github.io/odata-vocabularies/vocabularies/PDF.json" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="describedby" />
+            <PropertyValue Property="href" String="https://github.com/sap/odata-vocabularies/blob/main/vocabularies/PDF.md" />
+          </Record>
+        </Collection>
+      </Annotation>
+
+      <Term Name="Features" Type="PDF.FeaturesType" Nullable="false" AppliesTo="EntityContainer">
+        <Annotation Term="Common.Experimental" />
+        <Annotation Term="Core.Description" String="Features for the PDF" />
+      </Term>
+
+      <ComplexType Name="FeaturesType">
+        <Annotation Term="Common.Experimental" />
+        <Property Name="DocumentDescriptionReference" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.IsURL" Bool="true" />
+          <Annotation Term="Core.Description" String="Reference of the Service for the DocumentDescription" />
+        </Property>
+        <Property Name="DocumentDescriptionCollection" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="Name of entity set containing the DocumentDescription" />
+        </Property>
+        <Property Name="ArchiveFormat" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="Core.Description" String="PDFA conformant format" />
+        </Property>
+        <Property Name="Signature" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="Core.Description" String="Signing the document" />
+        </Property>
+        <Property Name="CoverPage" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="Core.Description" String="Cover Page" />
+        </Property>
+        <Property Name="FontName" Type="Edm.String">
+          <Annotation Term="Core.Description" String="Font name" />
+        </Property>
+        <Property Name="FontSize" Type="Edm.Int16">
+          <Annotation Term="Core.Description" String="Font size" />
+        </Property>
+        <Property Name="Margin" Type="Edm.Int16">
+          <Annotation Term="Core.Description" String="Margin size" />
+        </Property>
+        <Property Name="Border" Type="Edm.Int16">
+          <Annotation Term="Core.Description" String="Border size of the table" />
+        </Property>
+        <Property Name="FitToPage" Type="Edm.Boolean" DefaultValue="false">
+          <Annotation Term="Core.Description" String="Fit to page" />
+          <Annotation Term="Core.LongDescription">
+            <String>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.</String>
+          </Annotation>
+        </Property>
+        <Property Name="ResultSizeDefault" Type="Edm.Int32">
+          <Annotation Term="Core.Description" String="Default result size" />
+          <Annotation Term="Core.LongDescription">
+            <String> Default result size for PDF documents. Used if a the $top has not been provided.</String>
+          </Annotation>
+        </Property>
+        <Property Name="ResultSizeMaximum" Type="Edm.Int32">
+          <Annotation Term="Core.Description" String="Maximum result size" />
+          <Annotation Term="Core.LongDescription">
+            <String>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum</String>
+          </Annotation>
+        </Property>
+      </ComplexType>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
Margin, Border, FitToPage, FontSize, & FontName are new features of the PDF_API. The annotation shows you if this option is available from the server.
=> Changing the types to boolean.

We have no default FontName, FonstSize and so on. Only the pdf API knows this. If the pdf API add this default knowledge, it could be (for an older FES), that this information is not available. Then we would have to set NULL for these default FontName, FontSize, etc. setting. Therefore, I would not add this here. 