### PR TITLE
Dynamic Properties example

### DIFF
--- a/examples/DynamicProperties-sample.json
+++ b/examples/DynamicProperties-sample.json
@@ -83,7 +83,7 @@
                             "Property": "Country"
                         },
                         {
-                            "DynamicProperty": "@Analytics.AggregatedProperty#sum",
+                            "DynamicProperty": "@Analytics.AggregatedProperty#sumAmount",
                             "Descending": true
                         },
                         {

--- a/examples/DynamicProperties-sample.json
+++ b/examples/DynamicProperties-sample.json
@@ -35,9 +35,6 @@
             ],
             "Order": {},
             "Country": {},
-            "NumberOfItems": {
-                "$Type": "Edm.Int16"
-            },
             "Amount": {
                 "$Type": "Edm.Decimal",
                 "$Nullable": true,
@@ -46,12 +43,12 @@
         },
         "$Annotations": {
             "self.Sales": {
-                "@Analytics.AggregatedProperty#sum": {
+                "@Analytics.AggregatedProperty#sumAmount": {
                     "Name": "Total",
                     "AggregationMethod": "sum",
                     "AggregatableProperty": "Amount"
                 },
-                "@Analytics.AggregatedProperty#max": {
+                "@Analytics.AggregatedProperty#maxAmount": {
                     "Name": "Maximum",
                     "AggregationMethod": "max",
                     "AggregatableProperty": "Amount"
@@ -61,18 +58,15 @@
                     "Dimensions": [
                         "Country"
                     ],
-                    "Measures": [
-                        "NumberOfItems"
-                    ],
                     "DynamicMeasures": [
-                        "@Analytics.AggregatedProperty#sum",
+                        "@Analytics.AggregatedProperty#sumAmount",
                         "/self.Container/me/SalesOrders@Aggregation.CustomAggregate#WeightedAverage"
                     ]
                 },
                 "@UI.SelectionVariant": {
                     "SelectOptions": [
                         {
-                            "DynamicPropertyName": "@Analytics.AggregatedProperty#sum",
+                            "DynamicPropertyName": "@Analytics.AggregatedProperty#sumAmount",
                             "Ranges": [
                                 {
                                     "Sign": "I",

--- a/examples/DynamicProperties-sample.xml
+++ b/examples/DynamicProperties-sample.xml
@@ -87,7 +87,7 @@
                   <PropertyValue Property="Property" PropertyPath="Country" />
                 </Record>
                 <Record>
-                  <PropertyValue Property="DynamicProperty" AnnotationPath="@Analytics.AggregatedProperty#sum" />
+                  <PropertyValue Property="DynamicProperty" AnnotationPath="@Analytics.AggregatedProperty#sumAmount" />
                   <PropertyValue Property="Descending" Bool="true" />
                 </Record>
                 <Record>

--- a/examples/DynamicProperties-sample.xml
+++ b/examples/DynamicProperties-sample.xml
@@ -18,12 +18,11 @@
         </Key>
         <Property Name="Order" Type="Edm.String" Nullable="false" />
         <Property Name="Country" Type="Edm.String" Nullable="false" />
-        <Property Name="NumberOfItems" Type="Edm.Int16" Nullable="false" />
         <Property Name="Amount" Type="Edm.Decimal" />
       </EntityType>
 
       <Annotations Target="self.Sales">
-        <Annotation Term="Analytics.AggregatedProperty" Qualifier="sum">
+        <Annotation Term="Analytics.AggregatedProperty" Qualifier="sumAmount">
           <Record>
             <PropertyValue Property="Name" String="Total" />
             <PropertyValue Property="AggregationMethod" String="sum" />
@@ -31,7 +30,7 @@
           </Record>
         </Annotation>
 
-        <Annotation Term="Analytics.AggregatedProperty" Qualifier="max">
+        <Annotation Term="Analytics.AggregatedProperty" Qualifier="maxAmount">
           <Record>
             <PropertyValue Property="Name" String="Maximum" />
             <PropertyValue Property="AggregationMethod" String="max" />
@@ -47,14 +46,9 @@
                 <PropertyPath>Country</PropertyPath>
               </Collection>
             </PropertyValue>
-            <PropertyValue Property="Measures">
-              <Collection>
-                <PropertyPath>NumberOfItems</PropertyPath>
-              </Collection>
-            </PropertyValue>
             <PropertyValue Property="DynamicMeasures">
               <Collection>
-                <AnnotationPath>@Analytics.AggregatedProperty#sum</AnnotationPath>
+                <AnnotationPath>@Analytics.AggregatedProperty#sumAmount</AnnotationPath>
                 <AnnotationPath>/self.Container/me/SalesOrders@Aggregation.CustomAggregate#WeightedAverage</AnnotationPath>
               </Collection>
             </PropertyValue>
@@ -69,7 +63,7 @@
             <PropertyValue Property="SelectOptions">
               <Collection>
                 <Record>
-                  <PropertyValue Property="DynamicPropertyName" AnnotationPath="@Analytics.AggregatedProperty#sum" />
+                  <PropertyValue Property="DynamicPropertyName" AnnotationPath="@Analytics.AggregatedProperty#sumAmount" />
                   <PropertyValue Property="Ranges">
                     <Collection>
                       <Record>


### PR DESCRIPTION
> As a general note, the example lacks an Aggregation.ApplySupported annotation, right?

The example is not meant to illustrate that.

> Either remove NumberOfItems from the Chart annotation or adjust the example and define it as CustomAggregate or as another AggregatedProperty.

Removed it.

> Finally, changing #sum to #totalAmount and #max to #maxAmount would improve readability of the example

Done.