### PR TITLE
Add padding flag to PDF features.

### DIFF
--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -27,5 +27,6 @@ Property|Type|Description
 [Margin](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size
 [Border](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table
 [FitToPage](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
+[Padding](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document<br>Sets the padding (left, right, bottom, top) in PDF units. The value must be > 0.
 [ResultSizeDefault](./PDF.xml#L77:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if $top has not been provided.
 [ResultSizeMaximum](./PDF.xml#L83:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum

--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -27,6 +27,6 @@ Property|Type|Description
 [Margin](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size
 [Border](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table
 [FitToPage](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
-[Padding](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document<br>Sets the padding (left, right, bottom, top) in PDF units. 
+[Padding](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document<br>Is padding (left, right, bottom, top) supported?
 [ResultSizeDefault](./PDF.xml#L77:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if $top has not been provided.
 [ResultSizeMaximum](./PDF.xml#L83:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum

--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -27,6 +27,6 @@ Property|Type|Description
 [Margin](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size
 [Border](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table
 [FitToPage](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
-[Padding](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document<br>Sets the padding (left, right, bottom, top) in PDF units. The value must be > 0.
+[Padding](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document<br>Sets the padding (left, right, bottom, top) in PDF units. 
 [ResultSizeDefault](./PDF.xml#L77:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if $top has not been provided.
 [ResultSizeMaximum](./PDF.xml#L83:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum

--- a/vocabularies/PDF.xml
+++ b/vocabularies/PDF.xml
@@ -77,7 +77,7 @@
         <Property Name="Padding" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
           <Annotation Term="Core.Description" String="Padding of document" />
           <Annotation Term="Core.LongDescription">
-            <String>Sets the padding (left, right, bottom, top) in PDF units</String>
+            <String>Is padding (left, right, bottom, top) supported?</String>
           </Annotation>
         </Property>
         <Property Name="ResultSizeDefault" Type="Edm.Int32">

--- a/vocabularies/PDF.xml
+++ b/vocabularies/PDF.xml
@@ -74,6 +74,12 @@
             <String>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.</String>
           </Annotation>
         </Property>
+        <Property Name="Padding" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
+          <Annotation Term="Core.Description" String="Padding of document" />
+          <Annotation Term="Core.LongDescription">
+            <String>Sets the padding (left, right, bottom, top) in PDF units. The value must be > 0</String>
+          </Annotation>
+        </Property>
         <Property Name="ResultSizeDefault" Type="Edm.Int32">
           <Annotation Term="Core.Description" String="Default result size" />
           <Annotation Term="Core.LongDescription">

--- a/vocabularies/PDF.xml
+++ b/vocabularies/PDF.xml
@@ -77,7 +77,7 @@
         <Property Name="Padding" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
           <Annotation Term="Core.Description" String="Padding of document" />
           <Annotation Term="Core.LongDescription">
-            <String>Sets the padding (left, right, bottom, top) in PDF units. The value must be > 0</String>
+            <String>Sets the padding (left, right, bottom, top) in PDF units</String>
           </Annotation>
         </Property>
         <Property Name="ResultSizeDefault" Type="Edm.Int32">


### PR DESCRIPTION
Add padding flag to PDF. New boolean value to see if the server supports the "padding" option. 

"Sets the padding (left, right, bottom, top) in PDF units. The value must be > 0."