### PR TITLE
Refreshed PDF.json and package-lock.json

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,11 @@
+{
+  "overrides": [
+    {
+      "files": ["examples/*.json", "vocabularies/*.json"],
+      "options": {
+        "parser": "json",
+        "printWidth": 120
+      }
+    }
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -109,9 +109,9 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.8.1",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.1.tgz",
-      "integrity": "sha512-7zFpHzhnqYKrkYdUjF1HI1bzd0VygEGX8lFk4k5zVMqHEoES+P+7TKI+EvLO9WVMJ8eekdO0aDEK044xTXwPPA==",
+      "version": "8.8.2",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.8.2.tgz",
+      "integrity": "sha512-xjIYgE8HBrkpd/sJqOGNspf8uHG+NOHGOw6a/Urj8taM2EXfdNAH2oFcPeIFfsv3+kz/mJrS5VuMqbNLjCa2vw==",
       "dev": true,
       "bin": {
         "acorn": "bin/acorn"
@@ -310,9 +310,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "8.31.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.31.0.tgz",
-      "integrity": "sha512-0tQQEVdmPZ1UtUKXjX7EMm9BlgJ08G90IhWh0PKDCb3ZLsgAOHI8fYSIzYVZej92zsgq+ft0FGsxhJ3xo2tbuA==",
+      "version": "8.32.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.32.0.tgz",
+      "integrity": "sha512-nETVXpnthqKPFyuY2FNjz/bEd6nbosRgKbkgS/y1C7LJop96gYHWpiguLecMHQ2XCPxn77DS0P+68WzG6vkZSQ==",
       "dev": true,
       "dependencies": {
         "@eslint/eslintrc": "^1.4.1",
@@ -702,9 +702,9 @@
       "dev": true
     },
     "node_modules/js-sdsl": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.2.0.tgz",
-      "integrity": "sha512-dyBIzQBDkCqCu+0upx25Y2jGdbTGxE9fshMsCdK0ViOongpV+n5tXRcZY9v7CaVQ79AGS9KA1KHtojxiM7aXSQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/js-sdsl/-/js-sdsl-4.3.0.tgz",
+      "integrity": "sha512-mifzlm2+5nZ+lEcLJMoBK0/IH/bDg8XnJfd/Wq6IP+xoCjLZsTOnV2QpxlVbX9bMnkl5PdEjNtBJ9Cj1NjifhQ==",
       "dev": true,
       "funding": {
         "type": "opencollective",
@@ -816,7 +816,7 @@
     },
     "node_modules/odata-vocabularies": {
       "version": "0.4.9",
-      "resolved": "git+ssh://git@github.com/oasis-tcs/odata-vocabularies.git#e35fb3cbe57f7c66e18c7af1b5d3536af36316b7",
+      "resolved": "git+ssh://git@github.com/oasis-tcs/odata-vocabularies.git#814f2fdc1828d321a707de4c2da8cc7f128a0a29",
       "license": "SEE LICENSE IN LICENSE.md",
       "dependencies": {
         "colors": "^1.4.0",
@@ -932,9 +932,9 @@
       }
     },
     "node_modules/prettier": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.2.tgz",
-      "integrity": "sha512-BtRV9BcncDyI2tsuS19zzhzoxD8Dh8LiCx7j7tHzrkz8GFXAexeWFdi22mjE1d16dftH2qNaytVxqiRTGlMfpw==",
+      "version": "2.8.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.8.3.tgz",
+      "integrity": "sha512-tJ/oJ4amDihPoufT5sM0Z1SKEuKay8LfVAMlbbhnnkvt6BUserZylqo2PN+p9KeljLr0OHa2rXHU1T8reeoTrw==",
       "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
@@ -947,9 +947,9 @@
       }
     },
     "node_modules/punycode": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
-      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.3.0.tgz",
+      "integrity": "sha512-rRV+zQD8tVFys26lAGR9WUuS4iUAngJScM+ZRSKtvl5tKeZ2t5bvdNFdNHBW9FWR4guGHlgmsZ1G7BSm2wTbuA==",
       "dev": true,
       "engines": {
         "node": ">=6"

--- a/vocabularies/PDF.json
+++ b/vocabularies/PDF.json
@@ -36,12 +36,20 @@
         "$DefaultValue": false,
         "@Core.Description": "PDF/A conformant format supported"
       },
-      "Signature": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Signing the document supported" },
+      "Signature": {
+        "$Type": "Edm.Boolean",
+        "$DefaultValue": false,
+        "@Core.Description": "Signing the document supported"
+      },
       "CoverPage": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Cover Page supported" },
       "FontName": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Font name supported" },
       "FontSize": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Font size supported" },
       "Margin": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Margin size supported" },
-      "Border": { "$Type": "Edm.Boolean", "$DefaultValue": false, "@Core.Description": "Border size of the table supported" },
+      "Border": {
+        "$Type": "Edm.Boolean",
+        "$DefaultValue": false,
+        "@Core.Description": "Border size of the table supported"
+      },
       "FitToPage": {
         "$Type": "Edm.Boolean",
         "$DefaultValue": false,


### PR DESCRIPTION
Action run https://github.com/SAP/odata-vocabularies/actions/runs/4022881409 on `main` failed due to a format mismatch, apparently in `PDF.json`.

- Refreshed `PDF.json`
- Refreshed `package-lock.json`
- Added `.prettierrc.json` with settings used in `transform.js`