### PR TITLE
docs(UI): Fix typo: "is is" -> "is"

### DIFF
--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1411,7 +1411,7 @@
       "$Kind": "ComplexType",
       "$BaseType": "UI.DataFieldForActionAbstract",
       "@Core.Description": "Triggers intent-based UI navigation",
-      "@Core.LongDescription": "The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.\n\nIt is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation)).\"",
+      "@Core.LongDescription": "The navigation intent is expressed as a Semantic Object and optionally an Action on that object.\n\nIt is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation)).\"",
       "SemanticObject": { "@Core.Description": "Name of the Semantic Object" },
       "Action": {
         "$Nullable": true,
@@ -1488,7 +1488,7 @@
       "$Kind": "ComplexType",
       "$BaseType": "UI.DataField",
       "@Core.Description": "A piece of data that allows triggering intent-based UI navigation",
-      "@Core.LongDescription": "The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.\n\nIt is tied to a data value which should be rendered as a hyperlink.\nThis is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBasedNavigation) which is not tied to a specific data value.",
+      "@Core.LongDescription": "The navigation intent is expressed as a Semantic Object and optionally an Action on that object.\n\nIt is tied to a data value which should be rendered as a hyperlink.\nThis is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBasedNavigation) which is not tied to a specific data value.",
       "Value": { "$Type": "Edm.PrimitiveType" },
       "SemanticObject": { "@Core.Description": "Name of the Semantic Object" },
       "Action": {

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -890,7 +890,7 @@ Member|Value|Description
 ## [DataFieldForIntentBasedNavigation](./UI.xml#L1551:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers intent-based UI navigation
 
-The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.
+The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
 
 It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation))."
 
@@ -987,7 +987,7 @@ Property|Type|Description
 ## [DataFieldWithIntentBasedNavigation](./UI.xml#L1621:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-"): [DataField](#DataField)
 A piece of data that allows triggering intent-based UI navigation
 
-The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.
+The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
 
 It is tied to a data value which should be rendered as a hyperlink.
 This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBasedNavigation) which is not tied to a specific data value.

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1551,7 +1551,7 @@ or `204 No Content` if the request included a `Prefer` header with a value of `r
       <ComplexType Name="DataFieldForIntentBasedNavigation" BaseType="UI.DataFieldForActionAbstract">
         <Annotation Term="Core.Description" String="Triggers intent-based UI navigation" />
         <Annotation Term="Core.LongDescription">
-          <String>The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.
+          <String>The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
 
 It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation))."</String>
         </Annotation>
@@ -1621,7 +1621,7 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
       <ComplexType Name="DataFieldWithIntentBasedNavigation" BaseType="UI.DataField">
         <Annotation Term="Core.Description" String="A piece of data that allows triggering intent-based UI navigation" />
         <Annotation Term="Core.LongDescription">
-          <String>The navigation intent is is expressed as a Semantic Object and optionally an Action on that object.
+          <String>The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
 
 It is tied to a data value which should be rendered as a hyperlink.
 This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBasedNavigation) which is not tied to a specific data value.</String>


### PR DESCRIPTION
This is a typo-fix only. I'm following https://github.com/SAP/odata-vocabularies/blob/main/CONTRIBUTING.md and have run `npm run build` locally.

Kind regards,
Andre Meyering