### PR TITLE
Fix: don't recommend deprecated VS Code extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -2,7 +2,6 @@
   "recommendations": [
     "bierner.github-markdown-preview",
     "dbaeumer.vscode-eslint",
-    "eg2.vscode-npm-script",
     "esbenp.prettier-vscode",
     "hbenl.vscode-mocha-test-adapter",
     "hbenl.vscode-test-explorer",


### PR DESCRIPTION
VS Code extension https://marketplace.visualstudio.com/items?itemName=eg2.vscode-npm-script has been deprecated, don't recommend it any more