### PR TITLE
Annotate hierarchy maintenance actions

### DIFF
--- a/examples/UI.SelectionAction-sample.json
+++ b/examples/UI.SelectionAction-sample.json
@@ -1,0 +1,72 @@
+{
+  "$Version": "4.0",
+  "$Reference": {
+    "https://oasis-tcs.github.io/odata-vocabularies/examples/Org.OData.Aggregation.V1.SalesModel-sample.xml": {
+      "$Include": [{ "$Namespace": "org.example.odata.salesservice", "$Alias": "SalesModel" }]
+    },
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Core.V1", "$Alias": "Core" }]
+    },
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Aggregation.V1", "$Alias": "Aggregation" }]
+    },
+    "https://sap.github.io/odata-vocabularies/vocabularies/UI.json": {
+      "$Include": [{ "$Namespace": "com.sap.vocabularies.UI.v1", "$Alias": "UI" }]
+    }
+  },
+  "UI.examples": {
+    "$Alias": "this",
+    "LinkAction": [
+      {
+        "$Kind": "Action",
+        "$IsBound": true,
+        "@Core.Description": "Drag a sales organization to a new parent",
+        "@UI.SelectionAction#SalesOrgHierarchy": {
+          "@odata.type": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml#UI.DragSelectionActionType",
+          "SelectionParameter": "Child",
+          "DropTargetParameter": "Parent",
+          "QualifierParameter": "HierarchyQualifier"
+        },
+        "$Parameter": [
+          { "$Name": "Child", "$Type": "SalesModel.SalesOrganization" },
+          { "$Name": "HierarchyQualifier", "$Type": "Aggregation.HierarchyQualifier" },
+          { "$Name": "Parent", "$Type": "SalesModel.SalesOrganization" }
+        ]
+      }
+    ],
+    "UnlinkAction": [
+      {
+        "$Kind": "Action",
+        "$IsBound": true,
+        "@Core.Description": "Unlink a sales organization from its parent",
+        "@UI.SelectionAction#SalesOrgHierarchy": {
+          "@odata.type": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml#UI.DeleteSelectionActionType",
+          "SelectionParameter": "Child",
+          "QualifierParameter": "HierarchyQualifier"
+        },
+        "$Parameter": [
+          { "$Name": "Child", "$Type": "SalesModel.SalesOrganization" },
+          { "$Name": "HierarchyQualifier", "$Type": "Aggregation.HierarchyQualifier" }
+        ]
+      }
+    ],
+    "CopyAction": [
+      {
+        "$Kind": "Action",
+        "$IsBound": true,
+        "@Core.Description": "Copy (ctrl+drag+drop) a sales organization to a new parent",
+        "@UI.SelectionAction#SalesOrgHierarchy": {
+          "@odata.type": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml#UI.CtrlDragSelectionActionType",
+          "SelectionParameter": "Child",
+          "DropTargetParameter": "Parent",
+          "QualifierParameter": "HierarchyQualifier"
+        },
+        "$Parameter": [
+          { "$Name": "Child", "$Type": "SalesModel.SalesOrganization" },
+          { "$Name": "HierarchyQualifier", "$Type": "Aggregation.HierarchyQualifier" },
+          { "$Name": "Parent", "$Type": "SalesModel.SalesOrganization" }
+        ]
+      }
+    ]
+  }
+}

--- a/examples/UI.SelectionAction-sample.xml
+++ b/examples/UI.SelectionAction-sample.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/examples/Org.OData.Aggregation.V1.SalesModel-sample.xml">
+    <edmx:Include Namespace="org.example.odata.salesservice" Alias="SalesModel" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml">
+    <edmx:Include Namespace="Org.OData.Aggregation.V1" Alias="Aggregation" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI" />
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema Namespace="UI.examples" xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="this">
+
+      <Action Name="LinkAction" IsBound="true">
+        <Annotation Term="Core.Description" String="Drag a sales organization to a new parent" />
+        <Annotation Term="UI.SelectionAction" Qualifier="SalesOrgHierarchy">
+          <Record Type="UI.DragSelectionActionType">
+            <PropertyValue Property="SelectionParameter" NavigationPropertyPath="Child" />
+            <PropertyValue Property="DropTargetParameter" NavigationPropertyPath="Parent" />
+            <PropertyValue Property="QualifierParameter" PropertyPath="HierarchyQualifier" />
+          </Record>
+        </Annotation>
+        <Parameter Name="Child" Type="SalesModel.SalesOrganization" Nullable="false" />
+        <Parameter Name="HierarchyQualifier" Type="Aggregation.HierarchyQualifier" Nullable="false" />
+        <Parameter Name="Parent" Type="SalesModel.SalesOrganization" Nullable="false" />
+      </Action>
+
+      <Action Name="UnlinkAction" IsBound="true">
+        <Annotation Term="Core.Description" String="Unlink a sales organization from its parent" />
+        <Annotation Term="UI.SelectionAction" Qualifier="SalesOrgHierarchy">
+          <Record Type="UI.DeleteSelectionActionType">
+            <PropertyValue Property="SelectionParameter" NavigationPropertyPath="Child" />
+            <PropertyValue Property="QualifierParameter" PropertyPath="HierarchyQualifier" />
+          </Record>
+        </Annotation>
+        <Parameter Name="Child" Type="SalesModel.SalesOrganization" Nullable="false" />
+        <Parameter Name="HierarchyQualifier" Type="Aggregation.HierarchyQualifier" Nullable="false" />
+      </Action>
+
+      <Action Name="CopyAction" IsBound="true">
+        <Annotation Term="Core.Description" String="Copy (ctrl+drag+drop) a sales organization to a new parent" />
+        <Annotation Term="UI.SelectionAction" Qualifier="SalesOrgHierarchy">
+          <Record Type="UI.CtrlDragSelectionActionType">
+            <PropertyValue Property="SelectionParameter" NavigationPropertyPath="Child" />
+            <PropertyValue Property="DropTargetParameter" NavigationPropertyPath="Parent" />
+            <PropertyValue Property="QualifierParameter" PropertyPath="HierarchyQualifier" />
+          </Record>
+        </Annotation>
+        <Parameter Name="Child" Type="SalesModel.SalesOrganization" Nullable="false" />
+        <Parameter Name="HierarchyQualifier" Type="Aggregation.HierarchyQualifier" Nullable="false" />
+        <Parameter Name="Parent" Type="SalesModel.SalesOrganization" Nullable="false" />
+      </Action>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1682,6 +1682,48 @@
       "@Common.Experimental": true,
       "@Core.Description": "The referenced entity set is the preferred starting point for UIs using this service"
     },
+    "SelectionAction": {
+      "$Kind": "Term",
+      "$Type": "UI.SelectionActionType",
+      "$AppliesTo": ["Action"],
+      "@Common.Experimental": true,
+      "@Core.Description": "The annotated action is executed during manipulation of a selection of entities"
+    },
+    "SelectionActionType": {
+      "$Kind": "ComplexType",
+      "$Abstract": true,
+      "@Common.Experimental": true,
+      "@Core.Description": "Specifies how to invoke the annotated action",
+      "@Core.LongDescription": "Different subtypes of this abstract type are used to associate the annotated action with\n          different types of manipulation of the selection.",
+      "SelectionParameter": {
+        "$Type": "Edm.NavigationPropertyPath",
+        "@Core.Description": "This action parameter is set to the selected entity or collection of entities"
+      },
+      "QualifierParameter": {
+        "$Type": "Edm.PropertyPath",
+        "$Nullable": true,
+        "@Core.Description": "This action parameter is set to the qualifier of this annotation"
+      }
+    },
+    "DeleteSelectionActionType": {
+      "$Kind": "ComplexType",
+      "$BaseType": "UI.SelectionActionType",
+      "@Core.Description": "Invocation of the annotated action when the delete button is pressed"
+    },
+    "DragSelectionActionType": {
+      "$Kind": "ComplexType",
+      "$BaseType": "UI.SelectionActionType",
+      "@Core.Description": "Invocation of the annotated action during drag and drop",
+      "DropTargetParameter": {
+        "$Type": "Edm.NavigationPropertyPath",
+        "@Core.Description": "This action parameter is set to the entity on which the selection is dropped"
+      }
+    },
+    "CtrlDragSelectionActionType": {
+      "$Kind": "ComplexType",
+      "$BaseType": "UI.DragSelectionActionType",
+      "@Core.Description": "Invocation of the annotated action during drag and drop with ctrl key pressed"
+    },
     "ActionName": {
       "$Kind": "TypeDefinition",
       "$UnderlyingType": "Edm.String",

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -75,6 +75,7 @@ Term|Type|Description
 [ExcludeFromNavigationContext](./UI.xml#L1821:~:text=<Term%20Name="-,ExcludeFromNavigationContext,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
 [DoNotCheckScaleOfMeasuredQuantity](./UI.xml#L1825:~:text=<Term%20Name="-,DoNotCheckScaleOfMeasuredQuantity,-") *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
 [LeadingEntitySet](./UI.xml#L1835:~:text=<Term%20Name="-,LeadingEntitySet,-") *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
+[SelectionAction](./UI.xml#L1840:~:text=<Term%20Name="-,SelectionAction,-") *([Experimental](Common.md#Experimental))*|[SelectionActionType](#SelectionActionType)|<a name="SelectionAction"></a>The annotated action is executed during manipulation of a selection of entities
 
 <a name="HeaderInfoType"></a>
 ## [HeaderInfoType](./UI.xml#L68:~:text=<ComplexType%20Name="-,HeaderInfoType,-")
@@ -1122,8 +1123,57 @@ Property|Type|Description
 [LocalDataProperty](./UI.xml#L1813:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|PropertyPath|Path to editable property for which recommended values exist
 [ValueListProperty](./UI.xml#L1816:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
 
+<a name="SelectionActionType"></a>
+## [*SelectionActionType*](./UI.xml#L1844:~:text=<ComplexType%20Name="-,SelectionActionType,-") *([Experimental](Common.md#Experimental))*
+Specifies how to invoke the annotated action
+
+Different subtypes of this abstract type are used to associate the annotated action with
+          different types of manipulation of the selection.
+
+**Derived Types:**
+- [DeleteSelectionActionType](#DeleteSelectionActionType)
+- [DragSelectionActionType](#DragSelectionActionType)
+  - [CtrlDragSelectionActionType](#CtrlDragSelectionActionType)
+
+Property|Type|Description
+:-------|:---|:----------
+[SelectionParameter](./UI.xml#L1851:~:text=<ComplexType%20Name="-,SelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the selected entity or collection of entities
+[QualifierParameter](./UI.xml#L1854:~:text=<ComplexType%20Name="-,SelectionActionType,-")|PropertyPath?|This action parameter is set to the qualifier of this annotation
+
+<a name="DeleteSelectionActionType"></a>
+## [DeleteSelectionActionType](./UI.xml#L1858:~:text=<ComplexType%20Name="-,DeleteSelectionActionType,-"): [SelectionActionType](#SelectionActionType)
+Invocation of the annotated action when the delete button is pressed
+
+Property|Type|Description
+:-------|:---|:----------
+[*SelectionParameter*](./UI.xml#L1851:~:text=<ComplexType%20Name="-,SelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the selected entity or collection of entities
+[*QualifierParameter*](./UI.xml#L1854:~:text=<ComplexType%20Name="-,SelectionActionType,-")|PropertyPath?|This action parameter is set to the qualifier of this annotation
+
+<a name="DragSelectionActionType"></a>
+## [DragSelectionActionType](./UI.xml#L1861:~:text=<ComplexType%20Name="-,DragSelectionActionType,-"): [SelectionActionType](#SelectionActionType)
+Invocation of the annotated action during drag and drop
+
+**Derived Types:**
+- [CtrlDragSelectionActionType](#CtrlDragSelectionActionType)
+
+Property|Type|Description
+:-------|:---|:----------
+[*SelectionParameter*](./UI.xml#L1851:~:text=<ComplexType%20Name="-,SelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the selected entity or collection of entities
+[*QualifierParameter*](./UI.xml#L1854:~:text=<ComplexType%20Name="-,SelectionActionType,-")|PropertyPath?|This action parameter is set to the qualifier of this annotation
+[DropTargetParameter](./UI.xml#L1863:~:text=<ComplexType%20Name="-,DragSelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the entity on which the selection is dropped
+
+<a name="CtrlDragSelectionActionType"></a>
+## [CtrlDragSelectionActionType](./UI.xml#L1867:~:text=<ComplexType%20Name="-,CtrlDragSelectionActionType,-"): [DragSelectionActionType](#DragSelectionActionType)
+Invocation of the annotated action during drag and drop with ctrl key pressed
+
+Property|Type|Description
+:-------|:---|:----------
+[*SelectionParameter*](./UI.xml#L1851:~:text=<ComplexType%20Name="-,SelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the selected entity or collection of entities
+[*QualifierParameter*](./UI.xml#L1854:~:text=<ComplexType%20Name="-,SelectionActionType,-")|PropertyPath?|This action parameter is set to the qualifier of this annotation
+[*DropTargetParameter*](./UI.xml#L1863:~:text=<ComplexType%20Name="-,DragSelectionActionType,-")|NavigationPropertyPath|This action parameter is set to the entity on which the selection is dropped
+
 <a name="ActionName"></a>
-## [ActionName](./UI.xml#L1840:~:text=<TypeDefinition%20Name="-,ActionName,-")
+## [ActionName](./UI.xml#L1871:~:text=<TypeDefinition%20Name="-,ActionName,-")
 **Type:** String
 
 Name of an Action, Function, ActionImport, or FunctionImport in scope

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1837,6 +1837,37 @@ This switches off the validation of user input with respect to decimals.</String
         <Annotation Term="Core.Description" String="The referenced entity set is the preferred starting point for UIs using this service" />
       </Term>
 
+      <Term Name="SelectionAction" Type="UI.SelectionActionType" Nullable="false" AppliesTo="Action">
+        <Annotation Term="Common.Experimental" />
+        <Annotation Term="Core.Description" String="The annotated action is executed during manipulation of a selection of entities" />
+      </Term>
+      <ComplexType Name="SelectionActionType" Abstract="true">
+        <Annotation Term="Common.Experimental" />
+        <Annotation Term="Core.Description" String="Specifies how to invoke the annotated action" />
+        <Annotation Term="Core.LongDescription">
+          <String>Different subtypes of this abstract type are used to associate the annotated action with
+          different types of manipulation of the selection.</String>
+        </Annotation>
+        <Property Name="SelectionParameter" Type="Edm.NavigationPropertyPath" Nullable="false">
+          <Annotation Term="Core.Description" String="This action parameter is set to the selected entity or collection of entities" />
+        </Property>
+        <Property Name="QualifierParameter" Type="Edm.PropertyPath" Nullable="true">
+          <Annotation Term="Core.Description" String="This action parameter is set to the qualifier of this annotation" />
+        </Property>
+      </ComplexType>
+      <ComplexType Name="DeleteSelectionActionType" BaseType="UI.SelectionActionType">
+        <Annotation Term="Core.Description" String="Invocation of the annotated action when the delete button is pressed" />
+      </ComplexType>
+      <ComplexType Name="DragSelectionActionType" BaseType="UI.SelectionActionType">
+        <Annotation Term="Core.Description" String="Invocation of the annotated action during drag and drop" />
+        <Property Name="DropTargetParameter" Type="Edm.NavigationPropertyPath" Nullable="false">
+          <Annotation Term="Core.Description" String="This action parameter is set to the entity on which the selection is dropped" />
+        </Property>
+      </ComplexType>
+      <ComplexType Name="CtrlDragSelectionActionType" BaseType="UI.DragSelectionActionType">
+        <Annotation Term="Core.Description" String="Invocation of the annotated action during drag and drop with ctrl key pressed" />
+      </ComplexType>
+
       <TypeDefinition Name="ActionName" UnderlyingType="Edm.String">
         <Annotation Term="Core.Description" String="Name of an Action, Function, ActionImport, or FunctionImport in scope" />
         <Annotation Term="Core.LongDescription">


### PR DESCRIPTION
Instead of following template actions, as in #247 and #254, annotate service-defined actions that shall be invoked when the user manipulates a recursive hierarchy on the UI.