### PR TITLE
PDF: support document description in request header

### DIFF
--- a/vocabularies/PDF.json
+++ b/vocabularies/PDF.json
@@ -26,11 +26,22 @@
     },
     "FeaturesType": {
       "$Kind": "ComplexType",
+      "DocumentDescriptionLocation": {
+        "$Type": "PDF.DocumentDescriptionLocation",
+        "$Nullable": true,
+        "$DefaultValue": 0,
+        "@Core.Description": "Whether the document description is given in an entity set or in a request header",
+        "@Core.LongDescription": "If value is 'entitySet', also set property 'DocumentDescriptionReference' and 'DocumentDescriptionCollection'. If value is 'header', set request header 'SAP-Document-Description' to base64-encoded JSON string of the document description."
+      },
       "DocumentDescriptionReference": {
+        "$Nullable": true,
         "@Core.IsURL": true,
         "@Core.Description": "Reference of the Service for the DocumentDescription"
       },
-      "DocumentDescriptionCollection": { "@Core.Description": "Name of entity set containing the DocumentDescription" },
+      "DocumentDescriptionCollection": {
+        "$Nullable": true,
+        "@Core.Description": "Name of entity set containing the DocumentDescription"
+      },
       "ArchiveFormat": {
         "$Type": "Edm.Boolean",
         "$DefaultValue": false,
@@ -81,6 +92,13 @@
         "@Core.Description": "Maximum result size",
         "@Core.LongDescription": "Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum"
       }
+    },
+    "DocumentDescriptionLocation": {
+      "$Kind": "EnumType",
+      "entitySet": 0,
+      "entitySet@Core.Description": "Document description is given as entity set",
+      "header": 1,
+      "header@Core.Description": "Document description is given in a request header"
     }
   }
 }

--- a/vocabularies/PDF.md
+++ b/vocabularies/PDF.md
@@ -18,17 +18,27 @@ Term|Type|Description
 
 Property|Type|Description
 :-------|:---|:----------
-[DocumentDescriptionReference](./PDF.xml#L43:~:text=<ComplexType%20Name="-,FeaturesType,-")|URL|Reference of the Service for the DocumentDescription
-[DocumentDescriptionCollection](./PDF.xml#L47:~:text=<ComplexType%20Name="-,FeaturesType,-")|String|Name of entity set containing the DocumentDescription
-[ArchiveFormat](./PDF.xml#L50:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|PDF/A conformant format supported
-[Signature](./PDF.xml#L53:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Signing the document supported
-[CoverPage](./PDF.xml#L56:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Cover Page supported
-[FontName](./PDF.xml#L59:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font name supported
-[FontSize](./PDF.xml#L62:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font size supported
-[Margin](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size supported
-[Border](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table supported
-[FitToPage](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page supported<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
-[Padding](./PDF.xml#L77:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document supported<br>Is padding (left, right, bottom, top) supported?
-[HeaderFooter](./PDF.xml#L83:~:text=<ComplexType%20Name="-,FeaturesType,-") *([Experimental](Common.md#Experimental))*|Boolean|Page header and footer supported<br>Headers and footers are areas in the top and the bottom page margins, where you can add page number and date information
-[ResultSizeDefault](./PDF.xml#L90:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if $top has not been provided.
-[ResultSizeMaximum](./PDF.xml#L96:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum
+[DocumentDescriptionLocation](./PDF.xml#L43:~:text=<ComplexType%20Name="-,FeaturesType,-")|[DocumentDescriptionLocation?](#DocumentDescriptionLocation)|Whether the document description is given in an entity set or in a request header<br>If value is 'entitySet', also set property 'DocumentDescriptionReference' and 'DocumentDescriptionCollection'. If value is 'header', set request header 'SAP-Document-Description' to base64-encoded JSON string of the document description.
+[DocumentDescriptionReference](./PDF.xml#L49:~:text=<ComplexType%20Name="-,FeaturesType,-")|URL?|Reference of the Service for the DocumentDescription
+[DocumentDescriptionCollection](./PDF.xml#L53:~:text=<ComplexType%20Name="-,FeaturesType,-")|String?|Name of entity set containing the DocumentDescription
+[ArchiveFormat](./PDF.xml#L56:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|PDF/A conformant format supported
+[Signature](./PDF.xml#L59:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Signing the document supported
+[CoverPage](./PDF.xml#L62:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Cover Page supported
+[FontName](./PDF.xml#L65:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font name supported
+[FontSize](./PDF.xml#L68:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Font size supported
+[Margin](./PDF.xml#L71:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Margin size supported
+[Border](./PDF.xml#L74:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Border size of the table supported
+[FitToPage](./PDF.xml#L77:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Fit to page supported<br>If this option is selected, the font size is automatically selected in such a way that all columns of a table fit on one page. Other layout options like margin, border and composite cell spacing are adapted accordingly, with respect to the chose scaling factor.
+[Padding](./PDF.xml#L83:~:text=<ComplexType%20Name="-,FeaturesType,-")|Boolean|Padding of document supported<br>Is padding (left, right, bottom, top) supported?
+[HeaderFooter](./PDF.xml#L89:~:text=<ComplexType%20Name="-,FeaturesType,-") *([Experimental](Common.md#Experimental))*|Boolean|Page header and footer supported<br>Headers and footers are areas in the top and the bottom page margins, where you can add page number and date information
+[ResultSizeDefault](./PDF.xml#L96:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Default result size<br>Default result size for PDF documents. Used if $top has not been provided.
+[ResultSizeMaximum](./PDF.xml#L102:~:text=<ComplexType%20Name="-,FeaturesType,-")|Int32?|Maximum result size<br>Max result size for PDF documents. Used if $top has been provided and $top > ResultSizeMaximum
+
+<a name="DocumentDescriptionLocation"></a>
+## [DocumentDescriptionLocation](./PDF.xml#L109:~:text=<EnumType%20Name="-,DocumentDescriptionLocation,-")
+
+
+Member|Value|Description
+:-----|----:|:----------
+[entitySet](./PDF.xml#L110:~:text=<EnumType%20Name="-,DocumentDescriptionLocation,-")|0|Document description is given as entity set
+[header](./PDF.xml#L113:~:text=<EnumType%20Name="-,DocumentDescriptionLocation,-")|1|Document description is given in a request header

--- a/vocabularies/PDF.xml
+++ b/vocabularies/PDF.xml
@@ -40,11 +40,17 @@
       </Term>
 
       <ComplexType Name="FeaturesType">
-        <Property Name="DocumentDescriptionReference" Type="Edm.String" Nullable="false">
+        <Property Name="DocumentDescriptionLocation" Type="PDF.DocumentDescriptionLocation" DefaultValue="0">
+          <Annotation Term="Core.Description" String="Whether the document description is given in an entity set or in a request header" />
+          <Annotation Term="Core.LongDescription">
+            <String>If value is 'entitySet', also set property 'DocumentDescriptionReference' and 'DocumentDescriptionCollection'. If value is 'header', set request header 'SAP-Document-Description' to base64-encoded JSON string of the document description.</String>
+          </Annotation>
+        </Property>
+        <Property Name="DocumentDescriptionReference" Type="Edm.String">
           <Annotation Term="Core.IsURL" Bool="true" />
           <Annotation Term="Core.Description" String="Reference of the Service for the DocumentDescription" />
         </Property>
-        <Property Name="DocumentDescriptionCollection" Type="Edm.String" Nullable="false">
+        <Property Name="DocumentDescriptionCollection" Type="Edm.String">
           <Annotation Term="Core.Description" String="Name of entity set containing the DocumentDescription" />
         </Property>
         <Property Name="ArchiveFormat" Type="Edm.Boolean" Nullable="false" DefaultValue="false">
@@ -100,6 +106,14 @@
           </Annotation>
         </Property>
       </ComplexType>
+      <EnumType Name="DocumentDescriptionLocation">
+        <Member Name="entitySet" Value="0">
+          <Annotation Term="Core.Description" String="Document description is given as entity set" />
+        </Member>
+        <Member Name="header" Value="1">
+          <Annotation Term="Core.Description" String="Document description is given in a request header" />
+        </Member>
+      </EnumType>
 
     </Schema>
   </edmx:DataServices>


### PR DESCRIPTION
Add `DocumentDescriptionLocation` to support this scenario.

Also, make `DocumentDescriptionReference` and `DocumentDescriptionCollection` optional.