### PR TITLE
Let diff-index compare only what add has staged

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -25,7 +25,7 @@ jobs:
           git config user.name ${GITHUB_ACTOR}
           git config user.email ${PUSHER_EMAIL}
           git add vocabularies/*.md vocabularies/*.json examples/*.json
-          git diff-index --quiet HEAD || git commit -m "auto-refreshed"
+          git diff-index --quiet HEAD vocabularies/*.md vocabularies/*.json examples/*.json || git commit -m "auto-refreshed"
           git push
         env:
           CI: true


### PR DESCRIPTION
The global `git diff-index --quiet HEAD` after the selective `git add vocabularies/*.md vocabularies/*.json examples/*.json` always exits with 1, because of the files that have not been added to the index.