### PR TITLE
Remove rendering proposal from DataFieldWithAction

### DIFF
--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1523,7 +1523,7 @@
       "$Kind": "ComplexType",
       "$BaseType": "UI.DataField",
       "@Core.Description": "A piece of data that allows triggering an OData action",
-      "@Core.LongDescription": "The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.",
+      "@Core.LongDescription": "The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.",
       "Value": { "$Type": "Edm.PrimitiveType" },
       "Action": {
         "$Type": "UI.ActionName",

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1523,7 +1523,7 @@
       "$Kind": "ComplexType",
       "$BaseType": "UI.DataField",
       "@Core.Description": "A piece of data that allows triggering an OData action",
-      "@Core.LongDescription": "The action is tied to a data value which should be rendered as a hyperlink. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.",
+      "@Core.LongDescription": "The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.",
       "Value": { "$Type": "Edm.PrimitiveType" },
       "Action": {
         "$Type": "UI.ActionName",

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -977,7 +977,7 @@ Property|Type|Description
 ## [DataFieldWithAction](./UI.xml#L1679:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
-The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.
+The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -977,7 +977,7 @@ Property|Type|Description
 ## [DataFieldWithAction](./UI.xml#L1679:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
-The action is tied to a data value which should be rendered as a hyperlink. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.
+The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1678,7 +1678,7 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
       <ComplexType Name="DataFieldWithAction" BaseType="UI.DataField">
         <Annotation Term="Core.Description" String="A piece of data that allows triggering an OData action" />
-        <Annotation Term="Core.LongDescription" String="The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value." />
+        <Annotation Term="Core.LongDescription" String="The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value." />
         <Property Name="Value" Type="Edm.PrimitiveType" Nullable="false" />
         <Property Name="Action" Type="UI.ActionName" Nullable="false">
           <Annotation Term="Core.Description" String="Name of an Action, Function, ActionImport, or FunctionImport in scope" />

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1678,7 +1678,7 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
       <ComplexType Name="DataFieldWithAction" BaseType="UI.DataField">
         <Annotation Term="Core.Description" String="A piece of data that allows triggering an OData action" />
-        <Annotation Term="Core.LongDescription" String="The action is tied to a data value which should be rendered as a hyperlink. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value." />
+        <Annotation Term="Core.LongDescription" String="The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction)) which is not tied to a specific data value." />
         <Property Name="Value" Type="Edm.PrimitiveType" Nullable="false" />
         <Property Name="Action" Type="UI.ActionName" Nullable="false">
           <Annotation Term="Core.Description" String="Name of an Action, Function, ActionImport, or FunctionImport in scope" />


### PR DESCRIPTION
The proposal for a DataFieldWithAction (to render it as a link) might be misleading, as actions are usually connected with buttons or similar.