### PR TITLE
Core.Example values have the wrong type

### DIFF
--- a/vocabularies/DataIntegration.json
+++ b/vocabularies/DataIntegration.json
@@ -29,20 +29,29 @@
       "$AppliesTo": ["Property"],
       "@Core.Description": "Original data type of the annotated property in its source system",
       "@Core.LongDescription": "The provider of an OData service maps its local type definitions to Edm types. Sometimes, specific type information is lost. This additional annotation gives the consumer hints about the type original type definition.",
-      "@Core.Example": { "@DataIntegration.OriginalDataType": "CHAR(000010)" }
+      "@Core.Example": {
+        "@odata.type": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml#Core.PrimitiveExampleValue",
+        "Value": "CHAR(000010)"
+      }
     },
     "OriginalName": {
       "$Kind": "Term",
       "@Core.Description": "Original name of the annotated model element in its source model",
       "@Core.LongDescription": "The provider of an OData service maps its local names to Edm identifiers, which may require removing or replacing characters that are not allowed.",
-      "@Core.Example": { "@DataIntegration.OriginalName": "what::is-in.a/name?" }
+      "@Core.Example": {
+        "@odata.type": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml#Core.PrimitiveExampleValue",
+        "Value": "what::is-in.a/name?"
+      }
     },
     "ConversionExit": {
       "$Kind": "Term",
       "$AppliesTo": ["Property"],
       "@Core.Description": "Identifier that describes the special output conversion of the annotated property in the source system",
       "@Core.LongDescription": "The provider of an OData service maps its local type definitions to Edm types. Sometimes, specific type information is lost. This additional annotation gives the consumer hints about the type original type definition.",
-      "@Core.Example": { "@DataIntegration.ConversionExit": "ALPHA" }
+      "@Core.Example": {
+        "@odata.type": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml#Core.PrimitiveExampleValue",
+        "Value": "ALPHA"
+      }
     },
     "SourceSystem": {
       "$Kind": "Term",

--- a/vocabularies/DataIntegration.xml
+++ b/vocabularies/DataIntegration.xml
@@ -37,8 +37,8 @@
         <Annotation Term="Core.Description" String="Original data type of the annotated property in its source system" />
         <Annotation Term="Core.LongDescription" String="The provider of an OData service maps its local type definitions to Edm types. Sometimes, specific type information is lost. This additional annotation gives the consumer hints about the type original type definition." />
         <Annotation Term="Core.Example">
-          <Record>
-            <Annotation Term="com.sap.vocabularies.DataIntegration.v1.OriginalDataType" String="CHAR(000010)" />
+          <Record Type="Core.PrimitiveExampleValue">
+            <PropertyValue Property="Value" String="CHAR(000010)" />
           </Record>
         </Annotation>
       </Term>
@@ -47,8 +47,8 @@
         <Annotation Term="Core.Description" String="Original name of the annotated model element in its source model" />
         <Annotation Term="Core.LongDescription" String="The provider of an OData service maps its local names to Edm identifiers, which may require removing or replacing characters that are not allowed." />
         <Annotation Term="Core.Example">
-          <Record>
-            <Annotation Term="com.sap.vocabularies.DataIntegration.v1.OriginalName" String="what::is-in.a/name?" />
+          <Record Type="Core.PrimitiveExampleValue">
+            <PropertyValue Property="Value" String="what::is-in.a/name?" />
           </Record>
         </Annotation>
       </Term>
@@ -57,8 +57,8 @@
         <Annotation Term="Core.Description" String="Identifier that describes the special output conversion of the annotated property in the source system" />
         <Annotation Term="Core.LongDescription" String="The provider of an OData service maps its local type definitions to Edm types. Sometimes, specific type information is lost. This additional annotation gives the consumer hints about the type original type definition." />
         <Annotation Term="Core.Example">
-          <Record>
-            <Annotation Term="com.sap.vocabularies.DataIntegration.v1.ConversionExit" String="ALPHA" />
+          <Record Type="Core.PrimitiveExampleValue">
+            <PropertyValue Property="Value" String="ALPHA" />
           </Record>
         </Annotation>
       </Term>

--- a/vocabularies/Session.json
+++ b/vocabularies/Session.json
@@ -24,12 +24,8 @@
       "$AppliesTo": ["EntitySet"],
       "@Core.Description": "The annotated entity set allows data modification only within a sticky session",
       "@Core.Example": {
-        "@Session.SessionOnlyStateSupported": {
-          "NewAction": "...",
-          "EditAction": "...",
-          "SaveAction": "...",
-          "DiscardAction": "..."
-        }
+        "@odata.type": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml#Core.ComplexExampleValue",
+        "Value": { "NewAction": "...", "EditAction": "...", "SaveAction": "...", "DiscardAction": "..." }
       }
     },
     "StickySessionSupportedType": {

--- a/vocabularies/Session.xml
+++ b/vocabularies/Session.xml
@@ -71,15 +71,15 @@ combined as one UI app.
       <Term Name="StickySessionSupported" Type="Session.StickySessionSupportedType" Nullable="false" AppliesTo="EntitySet">
         <Annotation Term="Core.Description" String="The annotated entity set allows data modification only within a sticky session" />
         <Annotation Term="Core.Example">
-          <Record>
-            <Annotation Term="Session.SessionOnlyStateSupported">
+          <Record Type="Core.ComplexExampleValue">
+            <PropertyValue Property="Value">
               <Record>
                 <PropertyValue Property="NewAction" String="..." />
                 <PropertyValue Property="EditAction" String="..." />
                 <PropertyValue Property="SaveAction" String="..." />
                 <PropertyValue Property="DiscardAction" String="..." />
               </Record>
-            </Annotation>
+            </PropertyValue>
           </Record>
         </Annotation>
       </Term>

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -153,7 +153,8 @@
       "$AppliesTo": ["EntityType"],
       "@Core.Description": "Group of semantically connected fields with a representation template and an optional label",
       "@Core.Example": {
-        "@UI.ConnectedFields#Material": {
+        "@type": "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml#Core.ComplexExampleValue",
+        "Value": {
           "Label": "Material",
           "Template": "{MaterialName} - {MaterialClassName}",
           "Data": {

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -171,8 +171,8 @@ a collection of business object instances, e.g. as a list or table.</String>
       <Term Name="ConnectedFields" Type="UI.ConnectedFieldsType" Nullable="false" AppliesTo="EntityType">
         <Annotation Term="Core.Description" String="Group of semantically connected fields with a representation template and an optional label" />
         <Annotation Term="Core.Example">
-          <Record>
-            <Annotation Term="com.sap.vocabularies.UI.v1.ConnectedFields" Qualifier="Material">
+          <Record Type="Core.ComplexExampleValue">
+            <PropertyValue Property="Value">
               <Record>
                 <PropertyValue Property="Label" String="Material" />
                 <PropertyValue Property="Template" String="{MaterialName} - {MaterialClassName}" />
@@ -191,7 +191,7 @@ a collection of business object instances, e.g. as a list or table.</String>
                   </Record>
                 </PropertyValue>
               </Record>
-            </Annotation>
+            </PropertyValue>
           </Record>
         </Annotation>
       </Term>


### PR DESCRIPTION
In the SAP vocabularies, `Core.Example` annotations have values that are not of the correct type `Core.ExampleValue`.