### PR TITLE
New term UI.InputMask

### DIFF
--- a/examples/UI.InputMask-sample.json
+++ b/examples/UI.InputMask-sample.json
@@ -1,0 +1,23 @@
+{
+  "$Version": "4.0",
+  "$Reference": {
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Core.V1", "$Alias": "Core" }]
+    },
+    "https://sap.github.io/odata-vocabularies/vocabularies/UI.json": {
+      "$Include": [{ "$Namespace": "com.sap.vocabularies.UI.v1", "$Alias": "UI" }]
+    }
+  },
+  "Examples": {
+    "$Alias": "this",
+    "container": { "$Kind": "EntityContainer", "Customers": { "$Collection": true, "$Type": "this.Customer_Type" } },
+    "Customer_Type": {
+      "$Kind": "EntityType",
+      "$Key": ["CustomerID"],
+      "CustomerID": { "$Type": "Edm.Guid" },
+      "DUNS": { "$Nullable": true, "$MaxLength": 9 }
+    },
+    "$Annotations": { "this.Customer_Type/DUNS": { "@UI.InputMask": { "Mask": "999999999" } } }
+  },
+  "$EntityContainer": "Examples.container"
+}

--- a/examples/UI.InputMask-sample.json
+++ b/examples/UI.InputMask-sample.json
@@ -15,9 +15,11 @@
       "$Kind": "EntityType",
       "$Key": ["CustomerID"],
       "CustomerID": { "$Type": "Edm.Guid" },
+      "DUNS": { "$Nullable": true, "$MaxLength": 9 },
       "SwiftCode": { "$Nullable": true, "$MaxLength": 11 }
     },
     "$Annotations": {
+      "this.Customer_Type/DUNS": { "@UI.InputMask": { "Mask": "99-999-9999" } },
       "this.Customer_Type/SwiftCode": {
         "@UI.InputMask": {
           "Mask": "CCCCCCAAAAA",

--- a/examples/UI.InputMask-sample.json
+++ b/examples/UI.InputMask-sample.json
@@ -15,9 +15,20 @@
       "$Kind": "EntityType",
       "$Key": ["CustomerID"],
       "CustomerID": { "$Type": "Edm.Guid" },
-      "DUNS": { "$Nullable": true, "$MaxLength": 9 }
+      "SwiftCode": { "$Nullable": true, "$MaxLength": 11 }
     },
-    "$Annotations": { "this.Customer_Type/DUNS": { "@UI.InputMask": { "Mask": "99-999-9999" } } }
+    "$Annotations": {
+      "this.Customer_Type/SwiftCode": {
+        "@UI.InputMask": {
+          "Mask": "CCCCCCAAAAA",
+          "Placeholder": ".",
+          "Rules": [
+            { "MaskSymbol": "C", "RegExp": "[A-Z]" },
+            { "MaskSymbol": "A", "RegExp": "[A-Z0-9]" }
+          ]
+        }
+      }
+    }
   },
   "$EntityContainer": "Examples.container"
 }

--- a/examples/UI.InputMask-sample.json
+++ b/examples/UI.InputMask-sample.json
@@ -17,7 +17,7 @@
       "CustomerID": { "$Type": "Edm.Guid" },
       "DUNS": { "$Nullable": true, "$MaxLength": 9 }
     },
-    "$Annotations": { "this.Customer_Type/DUNS": { "@UI.InputMask": { "Mask": "999999999" } } }
+    "$Annotations": { "this.Customer_Type/DUNS": { "@UI.InputMask": { "Mask": "99-999-9999" } } }
   },
   "$EntityContainer": "Examples.container"
 }

--- a/examples/UI.InputMask-sample.xml
+++ b/examples/UI.InputMask-sample.xml
@@ -19,15 +19,27 @@
           <PropertyRef Name="CustomerID" />
         </Key>
         <Property Name="CustomerID" Type="Edm.Guid" Nullable="false"/>
-        <Property Name="DUNS" Type="Edm.String" Nullable="true" MaxLength="9"/>
+        <Property Name="SwiftCode" Type="Edm.String" Nullable="true" MaxLength="11"/>
         <!-- ... and a lot more -->
       </EntityType>
 
-      <Annotations Target="Examples.Customer_Type/DUNS">
+      <Annotations Target="Examples.Customer_Type/SwiftCode">
         <Annotation Term="UI.InputMask">
           <Record>
-            <PropertyValue Property="Mask" String="99-999-9999" />
-            <!-- Data Universal Numbering System number issued by Dun & Bradstreet - might also be used without dashes "999999999"-->
+            <PropertyValue Property="Mask" String="CCCCCCAAAAA" />
+            <PropertyValue Property="Placeholder" String="." />
+            <PropertyValue Property="Rules">
+              <Collection>
+                <Record>
+                  <PropertyValue Property="MaskSymbol" String="C" />
+                  <PropertyValue Property="RegExp" String="[A-Z]" />
+                </Record>
+                <Record>
+                  <PropertyValue Property="MaskSymbol" String="A" />
+                  <PropertyValue Property="RegExp" String="[A-Z0-9]" />
+                </Record>
+              </Collection>
+            </PropertyValue>
           </Record>
         </Annotation>
       </Annotations>

--- a/examples/UI.InputMask-sample.xml
+++ b/examples/UI.InputMask-sample.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI" />
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema Namespace="Examples" xmlns="http://docs.oasis-open.org/odata/ns/edm" Alias="this">
+
+      <EntityContainer Name="container">
+        <EntitySet Name="Customers" EntityType="this.Customer_Type" />
+      </EntityContainer>
+
+      <EntityType Name="Customer_Type">
+        <Key>
+          <PropertyRef Name="CustomerID" />
+        </Key>
+        <Property Name="CustomerID" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="DUNS" Type="Edm.String" Nullable="true" MaxLength="9"/>
+        <!-- ... and a lot more -->
+      </EntityType>
+
+      <Annotations Target="Examples.Customer_Type/DUNS">
+        <Annotation Term="UI.InputMask">
+          <Record>
+            <PropertyValue Property="Mask" String="999999999" />
+            <!-- Data Universal Numbering System number issued by Dun & Bradstreet - nine-digit number might also be used with dashes for better readability "99-999-9999"-->
+          </Record>
+        </Annotation>
+      </Annotations>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/examples/UI.InputMask-sample.xml
+++ b/examples/UI.InputMask-sample.xml
@@ -26,8 +26,8 @@
       <Annotations Target="Examples.Customer_Type/DUNS">
         <Annotation Term="UI.InputMask">
           <Record>
-            <PropertyValue Property="Mask" String="999999999" />
-            <!-- Data Universal Numbering System number issued by Dun & Bradstreet - nine-digit number might also be used with dashes for better readability "99-999-9999"-->
+            <PropertyValue Property="Mask" String="99-999-9999" />
+            <!-- Data Universal Numbering System number issued by Dun & Bradstreet - might also be used without dashes "999999999"-->
           </Record>
         </Annotation>
       </Annotations>

--- a/examples/UI.InputMask-sample.xml
+++ b/examples/UI.InputMask-sample.xml
@@ -19,10 +19,19 @@
           <PropertyRef Name="CustomerID" />
         </Key>
         <Property Name="CustomerID" Type="Edm.Guid" Nullable="false"/>
+        <Property Name="DUNS" Type="Edm.String" Nullable="true" MaxLength="9"/>
         <Property Name="SwiftCode" Type="Edm.String" Nullable="true" MaxLength="11"/>
         <!-- ... and a lot more -->
       </EntityType>
 
+      <Annotations Target="Examples.Customer_Type/DUNS">
+        <Annotation Term="UI.InputMask">
+          <Record>
+            <PropertyValue Property="Mask" String="99-999-9999" />
+            <!-- Data Universal Numbering System number issued by Dun & Bradstreet - might also be used without dashes "999999999"-->
+          </Record>
+        </Annotation>
+      </Annotations>
       <Annotations Target="Examples.Customer_Type/SwiftCode">
         <Annotation Term="UI.InputMask">
           <Record>

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1253,7 +1253,7 @@
       "$Kind": "Term",
       "$Type": "UI.InputMaskType",
       "$AppliesTo": ["Property", "Parameter"],
-      "@Core.Description": "Properties or parameters annotated with this term will get a mask in edit mode.",
+      "@Core.Description": "Properties or parameters annotated with this term will get a mask in edit mode",
       "@Core.LongDescription": "Input masks improve readability and help to enter data correctly. \nSo, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. \n[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation"
     },
     "InputMaskType": {
@@ -1267,7 +1267,7 @@
       "InputMaskRules": {
         "$Collection": true,
         "$Type": "UI.InputMaskRuleType",
-        "@Core.Description": "Rules that define valid values for one symbol in the mask.",
+        "@Core.Description": "Rules that define valid values for one symbol in the mask",
         "@Core.LongDescription": "The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]"
       }
     },
@@ -1277,7 +1277,7 @@
         "$MaxLength": 1,
         "@Core.Description": "A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs"
       },
-      "RegExp": { "@Core.Description": "Regular expression that defines the valid values for the mask symbol." }
+      "RegExp": { "@Core.Description": "Regular expression that defines the valid values for the mask symbol" }
     },
     "TextArrangement": {
       "$Kind": "Term",

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1264,7 +1264,7 @@
         "$DefaultValue": "_",
         "@Core.Description": "A single character symbol to be shown where the user can type a character"
       },
-      "InputMaskRules": {
+      "Rules": {
         "$Collection": true,
         "$Type": "UI.InputMaskRuleType",
         "@Core.Description": "Rules that define valid values for one symbol in the mask",

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1273,7 +1273,10 @@
     },
     "InputMaskRuleType": {
       "$Kind": "ComplexType",
-      "MaskSymbol": { "@Core.Description": "The character in the mask that should be validated." },
+      "MaskSymbol": {
+        "$MaxLength": 1,
+        "@Core.Description": "A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs"
+      },
       "Rule": {
         "@Core.Description": "The rule that defines the valid values for the mask symbol as regular expression."
       }

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1249,6 +1249,35 @@
       "@Core.Description": "A short, human-readable text that gives a hint or an example to help the user with data entry",
       "@Core.IsLanguageDependent": true
     },
+    "InputMask": {
+      "$Kind": "Term",
+      "$Type": "UI.InputMaskType",
+      "$AppliesTo": ["Property", "Parameter"],
+      "@Core.Description": "Properties or parameters annotated with this term will get a mask in edit mode.",
+      "@Core.LongDescription": "Input masks not only improve readability, but also help to enter data correctly. \nSo, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. \n[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation"
+    },
+    "InputMaskType": {
+      "$Kind": "ComplexType",
+      "Mask": { "@Core.Description": "The mask to be applied to the property" },
+      "Placeholder": {
+        "$Nullable": true,
+        "$DefaultValue": "_",
+        "@Core.Description": "A single character symbol that is used as a substitute."
+      },
+      "InputMaskRule": {
+        "$Collection": true,
+        "$Type": "UI.InputMaskRuleType",
+        "@Core.Description": "Rules that define valid values for one symbol in the mask.",
+        "@Core.LongDescription": "The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]"
+      }
+    },
+    "InputMaskRuleType": {
+      "$Kind": "ComplexType",
+      "MaskSymbol": { "@Core.Description": "The character in the mask that should be validated." },
+      "Rule": {
+        "@Core.Description": "The rule that defines the valid values for the mask symbol as regular expression."
+      }
+    },
     "TextArrangement": {
       "$Kind": "Term",
       "$Type": "UI.TextArrangementType",

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1253,11 +1253,13 @@
       "$Kind": "Term",
       "$Type": "UI.InputMaskType",
       "$AppliesTo": ["Property", "Parameter"],
+      "@Common.Experimental": true,
       "@Core.Description": "Properties or parameters annotated with this term will get a mask in edit mode",
       "@Core.LongDescription": "Input masks improve readability and help to enter data correctly. \nSo, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. \n[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation"
     },
     "InputMaskType": {
       "$Kind": "ComplexType",
+      "@Common.Experimental": true,
       "Mask": { "@Core.Description": "The mask to be applied to the property or the parameter" },
       "Placeholder": {
         "$MaxLength": 1,
@@ -1273,6 +1275,7 @@
     },
     "InputMaskRuleType": {
       "$Kind": "ComplexType",
+      "@Common.Experimental": true,
       "MaskSymbol": {
         "$MaxLength": 1,
         "@Core.Description": "A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs"

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1268,7 +1268,7 @@
         "$Collection": true,
         "$Type": "UI.InputMaskRuleType",
         "@Core.Description": "Rules that define valid values for one symbol in the mask.",
-        "@Core.LongDescription": "The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]"
+        "@Core.LongDescription": "The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]"
       }
     },
     "InputMaskRuleType": {

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1262,7 +1262,7 @@
       "Placeholder": {
         "$Nullable": true,
         "$DefaultValue": "_",
-        "@Core.Description": "A single character symbol that is used as a substitute."
+        "@Core.Description": "A single character symbol to be shown where the user can type a character"
       },
       "InputMaskRule": {
         "$Collection": true,

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1260,7 +1260,7 @@
       "$Kind": "ComplexType",
       "Mask": { "@Core.Description": "The mask to be applied to the property or the parameter" },
       "Placeholder": {
-        "$Nullable": true,
+        "$MaxLength": 1,
         "$DefaultValue": "_",
         "@Core.Description": "A single character symbol to be shown where the user can type a character"
       },

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1254,17 +1254,17 @@
       "$Type": "UI.InputMaskType",
       "$AppliesTo": ["Property", "Parameter"],
       "@Core.Description": "Properties or parameters annotated with this term will get a mask in edit mode.",
-      "@Core.LongDescription": "Input masks not only improve readability, but also help to enter data correctly. \nSo, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. \n[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation"
+      "@Core.LongDescription": "Input masks improve readability and help to enter data correctly. \nSo, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. \n[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation"
     },
     "InputMaskType": {
       "$Kind": "ComplexType",
-      "Mask": { "@Core.Description": "The mask to be applied to the property" },
+      "Mask": { "@Core.Description": "The mask to be applied to the property or the parameter" },
       "Placeholder": {
         "$Nullable": true,
         "$DefaultValue": "_",
         "@Core.Description": "A single character symbol to be shown where the user can type a character"
       },
-      "InputMaskRule": {
+      "InputMaskRules": {
         "$Collection": true,
         "$Type": "UI.InputMaskRuleType",
         "@Core.Description": "Rules that define valid values for one symbol in the mask.",
@@ -1277,9 +1277,7 @@
         "$MaxLength": 1,
         "@Core.Description": "A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs"
       },
-      "Rule": {
-        "@Core.Description": "The rule that defines the valid values for the mask symbol as regular expression."
-      }
+      "RegExp": { "@Core.Description": "Regular expression that defines the valid values for the mask symbol." }
     },
     "TextArrangement": {
       "$Kind": "Term",

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -767,7 +767,7 @@ Property|Type|Description
 
 Property|Type|Description
 :-------|:---|:----------
-[MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|The character in the mask that should be validated.
+[MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
 [Rule](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|The rule that defines the valid values for the mask symbol as regular expression.
 
 <a name="TextArrangementType"></a>

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -54,7 +54,7 @@ Term|Type|Description
 [IsImage](./UI.xml#L1383:~:text=<Term%20Name="-,IsImage,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
 [MultiLineText](./UI.xml#L1394:~:text=<Term%20Name="-,MultiLineText,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
 [Placeholder](./UI.xml#L1399:~:text=<Term%20Name="-,Placeholder,-")|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode.<br>Input masks not only improve readability, but also help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode.<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
 [TextArrangement](./UI.xml#L1435:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
 [Note](./UI.xml#L1458:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
 [Importance](./UI.xml#L1511:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
@@ -757,9 +757,9 @@ Member|Value|Description
 
 Property|Type|Description
 :-------|:---|:----------
-[Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property
+[Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
 [Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol to be shown where the user can type a character
-[InputMaskRule](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[InputMaskRules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
 ## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")
@@ -768,7 +768,7 @@ Property|Type|Description
 Property|Type|Description
 :-------|:---|:----------
 [MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
-[Rule](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|The rule that defines the valid values for the mask symbol as regular expression.
+[RegExp](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|Regular expression that defines the valid values for the mask symbol.
 
 <a name="TextArrangementType"></a>
 ## [TextArrangementType](./UI.xml#L1443:~:text=<EnumType%20Name="-,TextArrangementType,-")

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -759,7 +759,7 @@ Property|Type|Description
 :-------|:---|:----------
 [Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property
 [Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol to be shown where the user can type a character
-[InputMaskRule](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]
+[InputMaskRule](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
 ## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -758,7 +758,7 @@ Member|Value|Description
 Property|Type|Description
 :-------|:---|:----------
 [Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property
-[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol that is used as a substitute.
+[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol to be shown where the user can type a character
 [InputMaskRule](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -758,7 +758,7 @@ Member|Value|Description
 Property|Type|Description
 :-------|:---|:----------
 [Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
-[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol to be shown where the user can type a character
+[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|A single character symbol to be shown where the user can type a character
 [InputMaskRules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -54,27 +54,28 @@ Term|Type|Description
 [IsImage](./UI.xml#L1383:~:text=<Term%20Name="-,IsImage,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
 [MultiLineText](./UI.xml#L1394:~:text=<Term%20Name="-,MultiLineText,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
 [Placeholder](./UI.xml#L1399:~:text=<Term%20Name="-,Placeholder,-")|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[TextArrangement](./UI.xml#L1404:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
-[Note](./UI.xml#L1427:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
-[Importance](./UI.xml#L1480:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
-[Hidden](./UI.xml#L1495:~:text=<Term%20Name="-,Hidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
-[IsCopyAction](./UI.xml#L1503:~:text=<Term%20Name="-,IsCopyAction,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
-[CreateHidden](./UI.xml#L1515:~:text=<Term%20Name="-,CreateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
-[UpdateHidden](./UI.xml#L1520:~:text=<Term%20Name="-,UpdateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[DeleteHidden](./UI.xml#L1525:~:text=<Term%20Name="-,DeleteHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[HiddenFilter](./UI.xml#L1530:~:text=<Term%20Name="-,HiddenFilter,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
-[AdaptationHidden](./UI.xml#L1539:~:text=<Term%20Name="-,AdaptationHidden,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
-[DataFieldDefault](./UI.xml#L1545:~:text=<Term%20Name="-,DataFieldDefault,-")|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
-[Criticality](./UI.xml#L1769:~:text=<Term%20Name="-,Criticality,-")|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
-[CriticalityCalculation](./UI.xml#L1773:~:text=<Term%20Name="-,CriticalityCalculation,-")|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
-[Emphasized](./UI.xml#L1777:~:text=<Term%20Name="-,Emphasized,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
-[OrderBy](./UI.xml#L1783:~:text=<Term%20Name="-,OrderBy,-") *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
-[ParameterDefaultValue](./UI.xml#L1789:~:text=<Term%20Name="-,ParameterDefaultValue,-")|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
-[RecommendationState](./UI.xml#L1795:~:text=<Term%20Name="-,RecommendationState,-")|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
-[RecommendationList](./UI.xml#L1825:~:text=<Term%20Name="-,RecommendationList,-")|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
-[ExcludeFromNavigationContext](./UI.xml#L1857:~:text=<Term%20Name="-,ExcludeFromNavigationContext,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
-[DoNotCheckScaleOfMeasuredQuantity](./UI.xml#L1861:~:text=<Term%20Name="-,DoNotCheckScaleOfMeasuredQuantity,-") *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
-[LeadingEntitySet](./UI.xml#L1871:~:text=<Term%20Name="-,LeadingEntitySet,-") *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
+[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode.<br>Input masks not only improve readability, but also help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[TextArrangement](./UI.xml#L1435:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
+[Note](./UI.xml#L1458:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
+[Importance](./UI.xml#L1511:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
+[Hidden](./UI.xml#L1526:~:text=<Term%20Name="-,Hidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
+[IsCopyAction](./UI.xml#L1534:~:text=<Term%20Name="-,IsCopyAction,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
+[CreateHidden](./UI.xml#L1546:~:text=<Term%20Name="-,CreateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
+[UpdateHidden](./UI.xml#L1551:~:text=<Term%20Name="-,UpdateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[DeleteHidden](./UI.xml#L1556:~:text=<Term%20Name="-,DeleteHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[HiddenFilter](./UI.xml#L1561:~:text=<Term%20Name="-,HiddenFilter,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
+[AdaptationHidden](./UI.xml#L1570:~:text=<Term%20Name="-,AdaptationHidden,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
+[DataFieldDefault](./UI.xml#L1576:~:text=<Term%20Name="-,DataFieldDefault,-")|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
+[Criticality](./UI.xml#L1800:~:text=<Term%20Name="-,Criticality,-")|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
+[CriticalityCalculation](./UI.xml#L1804:~:text=<Term%20Name="-,CriticalityCalculation,-")|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
+[Emphasized](./UI.xml#L1808:~:text=<Term%20Name="-,Emphasized,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
+[OrderBy](./UI.xml#L1814:~:text=<Term%20Name="-,OrderBy,-") *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
+[ParameterDefaultValue](./UI.xml#L1820:~:text=<Term%20Name="-,ParameterDefaultValue,-")|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
+[RecommendationState](./UI.xml#L1826:~:text=<Term%20Name="-,RecommendationState,-")|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
+[RecommendationList](./UI.xml#L1856:~:text=<Term%20Name="-,RecommendationList,-")|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
+[ExcludeFromNavigationContext](./UI.xml#L1888:~:text=<Term%20Name="-,ExcludeFromNavigationContext,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
+[DoNotCheckScaleOfMeasuredQuantity](./UI.xml#L1892:~:text=<Term%20Name="-,DoNotCheckScaleOfMeasuredQuantity,-") *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
+[LeadingEntitySet](./UI.xml#L1902:~:text=<Term%20Name="-,LeadingEntitySet,-") *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
 
 <a name="HeaderInfoType"></a>
 ## [HeaderInfoType](./UI.xml#L68:~:text=<ComplexType%20Name="-,HeaderInfoType,-")
@@ -750,41 +751,60 @@ Member|Value|Description
 [GT](./UI.xml#L1342:~:text=<EnumType%20Name="-,SelectionRangeOptionType,-")|8|Greater than
 [LT](./UI.xml#L1345:~:text=<EnumType%20Name="-,SelectionRangeOptionType,-")|9|Less than
 
-<a name="TextArrangementType"></a>
-## [TextArrangementType](./UI.xml#L1412:~:text=<EnumType%20Name="-,TextArrangementType,-")
-
-
-Member|Value|Description
-:-----|----:|:----------
-[TextFirst](./UI.xml#L1413:~:text=<EnumType%20Name="-,TextArrangementType,-")|0|Text is first, followed by the code/ID (e.g. in parentheses)
-[TextLast](./UI.xml#L1416:~:text=<EnumType%20Name="-,TextArrangementType,-")|1|Code/ID is first, followed by the text (e.g. separated by a dash)
-[TextSeparate](./UI.xml#L1419:~:text=<EnumType%20Name="-,TextArrangementType,-")|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
-[TextOnly](./UI.xml#L1422:~:text=<EnumType%20Name="-,TextArrangementType,-")|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
-
-<a name="NoteType"></a>
-## [NoteType](./UI.xml#L1439:~:text=<ComplexType%20Name="-,NoteType,-") *([Experimental](Common.md#Experimental))*
+<a name="InputMaskType"></a>
+## [InputMaskType](./UI.xml#L1412:~:text=<ComplexType%20Name="-,InputMaskType,-")
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](./UI.xml#L1441:~:text=<ComplexType%20Name="-,NoteType,-")|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
-[Content](./UI.xml#L1453:~:text=<ComplexType%20Name="-,NoteType,-")|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
-[Type](./UI.xml#L1469:~:text=<ComplexType%20Name="-,NoteType,-")|String|A type used for grouping notes
-[MaximalLength](./UI.xml#L1472:~:text=<ComplexType%20Name="-,NoteType,-")|Int32?|Type-specific maximal length of the content of the note
-[MultipleNotes](./UI.xml#L1475:~:text=<ComplexType%20Name="-,NoteType,-")|Boolean|Whether the type allows multiple notes for one object
+[Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property
+[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol that is used as a substitute.
+[InputMaskRule](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]
 
-<a name="ImportanceType"></a>
-## [ImportanceType](./UI.xml#L1483:~:text=<EnumType%20Name="-,ImportanceType,-")
+<a name="InputMaskRuleType"></a>
+## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")
+
+
+Property|Type|Description
+:-------|:---|:----------
+[MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|The character in the mask that should be validated.
+[Rule](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|The rule that defines the valid values for the mask symbol as regular expression.
+
+<a name="TextArrangementType"></a>
+## [TextArrangementType](./UI.xml#L1443:~:text=<EnumType%20Name="-,TextArrangementType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[High](./UI.xml#L1484:~:text=<EnumType%20Name="-,ImportanceType,-")|0|High importance
-[Medium](./UI.xml#L1487:~:text=<EnumType%20Name="-,ImportanceType,-")|1|Medium importance
-[Low](./UI.xml#L1490:~:text=<EnumType%20Name="-,ImportanceType,-")|2|Low importance
+[TextFirst](./UI.xml#L1444:~:text=<EnumType%20Name="-,TextArrangementType,-")|0|Text is first, followed by the code/ID (e.g. in parentheses)
+[TextLast](./UI.xml#L1447:~:text=<EnumType%20Name="-,TextArrangementType,-")|1|Code/ID is first, followed by the text (e.g. separated by a dash)
+[TextSeparate](./UI.xml#L1450:~:text=<EnumType%20Name="-,TextArrangementType,-")|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
+[TextOnly](./UI.xml#L1453:~:text=<EnumType%20Name="-,TextArrangementType,-")|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
+
+<a name="NoteType"></a>
+## [NoteType](./UI.xml#L1470:~:text=<ComplexType%20Name="-,NoteType,-") *([Experimental](Common.md#Experimental))*
+
+
+Property|Type|Description
+:-------|:---|:----------
+[Title](./UI.xml#L1472:~:text=<ComplexType%20Name="-,NoteType,-")|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
+[Content](./UI.xml#L1484:~:text=<ComplexType%20Name="-,NoteType,-")|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
+[Type](./UI.xml#L1500:~:text=<ComplexType%20Name="-,NoteType,-")|String|A type used for grouping notes
+[MaximalLength](./UI.xml#L1503:~:text=<ComplexType%20Name="-,NoteType,-")|Int32?|Type-specific maximal length of the content of the note
+[MultipleNotes](./UI.xml#L1506:~:text=<ComplexType%20Name="-,NoteType,-")|Boolean|Whether the type allows multiple notes for one object
+
+<a name="ImportanceType"></a>
+## [ImportanceType](./UI.xml#L1514:~:text=<EnumType%20Name="-,ImportanceType,-")
+
+
+Member|Value|Description
+:-----|----:|:----------
+[High](./UI.xml#L1515:~:text=<EnumType%20Name="-,ImportanceType,-")|0|High importance
+[Medium](./UI.xml#L1518:~:text=<EnumType%20Name="-,ImportanceType,-")|1|Medium importance
+[Low](./UI.xml#L1521:~:text=<EnumType%20Name="-,ImportanceType,-")|2|Low importance
 
 <a name="DataFieldAbstract"></a>
-## [*DataFieldAbstract*](./UI.xml#L1550:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")
+## [*DataFieldAbstract*](./UI.xml#L1581:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")
 Elementary building block that represents a piece of data and/or allows triggering an action
 
 By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the visibility, the importance and
@@ -805,10 +825,10 @@ By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[Criticality](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[CriticalityRepresentation](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[IconUrl](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Label](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[Criticality](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[CriticalityRepresentation](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[IconUrl](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
 
 **Applicable Annotation Terms:**
 
@@ -819,26 +839,26 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="CriticalityRepresentationType"></a>
-## [CriticalityRepresentationType](./UI.xml#L1581:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")
+## [CriticalityRepresentationType](./UI.xml#L1612:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[WithIcon](./UI.xml#L1582:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|0|Criticality is represented with an icon
-[WithoutIcon](./UI.xml#L1585:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|1|Criticality is represented without icon, e.g. only via text color
-[OnlyIcon](./UI.xml#L1588:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-") *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
+[WithIcon](./UI.xml#L1613:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|0|Criticality is represented with an icon
+[WithoutIcon](./UI.xml#L1616:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|1|Criticality is represented without icon, e.g. only via text color
+[OnlyIcon](./UI.xml#L1619:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-") *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
 
 <a name="DataFieldForAnnotation"></a>
-## [DataFieldForAnnotation](./UI.xml#L1594:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [DataFieldForAnnotation](./UI.xml#L1625:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-"): [DataFieldAbstract](#DataFieldAbstract)
 A structured piece of data described by an annotation
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Target](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-")|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Target](./UI.xml#L1627:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-")|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -849,7 +869,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionAbstract"></a>
-## [*DataFieldForActionAbstract*](./UI.xml#L1611:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [*DataFieldForActionAbstract*](./UI.xml#L1642:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-"): [DataFieldAbstract](#DataFieldAbstract)
 Triggers an action
 
 **Derived Types:**
@@ -858,12 +878,12 @@ Triggers an action
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Inline](./UI.xml#L1613:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[Determining](./UI.xml#L1616:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Inline](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[Determining](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
 
 **Applicable Annotation Terms:**
 
@@ -874,21 +894,21 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForAction"></a>
-## [DataFieldForAction](./UI.xml#L1621:~:text=<ComplexType%20Name="-,DataFieldForAction,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForAction](./UI.xml#L1652:~:text=<ComplexType%20Name="-,DataFieldForAction,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers an OData action
 
 The action is NOT tied to a data value (in contrast to [DataFieldWithAction](#DataFieldWithAction)).
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[*Inline*](./UI.xml#L1613:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](./UI.xml#L1616:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[Action](./UI.xml#L1624:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
-[InvocationGrouping](./UI.xml#L1627:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[*Inline*](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[Action](./UI.xml#L1655:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[InvocationGrouping](./UI.xml#L1658:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
 
 **Applicable Annotation Terms:**
 
@@ -899,16 +919,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="OperationGroupingType"></a>
-## [OperationGroupingType](./UI.xml#L1631:~:text=<EnumType%20Name="-,OperationGroupingType,-")
+## [OperationGroupingType](./UI.xml#L1662:~:text=<EnumType%20Name="-,OperationGroupingType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Isolated](./UI.xml#L1632:~:text=<EnumType%20Name="-,OperationGroupingType,-")|0|Invoke each action in isolation from other actions
-[ChangeSet](./UI.xml#L1635:~:text=<EnumType%20Name="-,OperationGroupingType,-")|1|Group all actions into a single change set
+[Isolated](./UI.xml#L1663:~:text=<EnumType%20Name="-,OperationGroupingType,-")|0|Invoke each action in isolation from other actions
+[ChangeSet](./UI.xml#L1666:~:text=<EnumType%20Name="-,OperationGroupingType,-")|1|Group all actions into a single change set
 
 <a name="DataFieldForIntentBasedNavigation"></a>
-## [DataFieldForIntentBasedNavigation](./UI.xml#L1640:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForIntentBasedNavigation](./UI.xml#L1671:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -917,17 +937,17 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[*Inline*](./UI.xml#L1613:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](./UI.xml#L1616:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[SemanticObject](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String|Name of the Semantic Object
-[Action](./UI.xml#L1650:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[NavigationAvailable](./UI.xml#L1653:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|The navigation intent is for that user with the selected context and parameters available
-[RequiresContext](./UI.xml#L1656:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|Determines whether a context needs to be passed to the target of this navigation.
-[Mapping](./UI.xml#L1659:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[*Inline*](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[SemanticObject](./UI.xml#L1678:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String|Name of the Semantic Object
+[Action](./UI.xml#L1681:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[NavigationAvailable](./UI.xml#L1684:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|The navigation intent is for that user with the selected context and parameters available
+[RequiresContext](./UI.xml#L1687:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|Determines whether a context needs to be passed to the target of this navigation.
+[Mapping](./UI.xml#L1690:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -938,16 +958,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionGroup"></a>
-## [DataFieldForActionGroup](./UI.xml#L1664:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-"): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
+## [DataFieldForActionGroup](./UI.xml#L1695:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-"): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Actions](./UI.xml#L1667:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-")|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Actions](./UI.xml#L1698:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-")|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
 
 **Applicable Annotation Terms:**
 
@@ -958,7 +978,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataField"></a>
-## [DataField](./UI.xml#L1672:~:text=<ComplexType%20Name="-,DataField,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [DataField](./UI.xml#L1703:~:text=<ComplexType%20Name="-,DataField,-"): [DataFieldAbstract](#DataFieldAbstract)
 A piece of data
 
 **Derived Types:**
@@ -970,11 +990,11 @@ A piece of data
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1674:~:text=<ComplexType%20Name="-,DataField,-")|Untyped|The data field's value
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1705:~:text=<ComplexType%20Name="-,DataField,-")|Untyped|The data field's value
 
 **Applicable Annotation Terms:**
 
@@ -985,19 +1005,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithAction"></a>
-## [DataFieldWithAction](./UI.xml#L1701:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
+## [DataFieldWithAction](./UI.xml#L1732:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
 The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1704:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|PrimitiveType|The data field's value
-[Action](./UI.xml#L1705:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1735:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|PrimitiveType|The data field's value
+[Action](./UI.xml#L1736:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
 
 **Applicable Annotation Terms:**
 
@@ -1008,7 +1028,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithIntentBasedNavigation"></a>
-## [DataFieldWithIntentBasedNavigation](./UI.xml#L1710:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-"): [DataField](#DataField)
+## [DataFieldWithIntentBasedNavigation](./UI.xml#L1741:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-"): [DataField](#DataField)
 A piece of data that allows triggering intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -1018,14 +1038,14 @@ This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBa
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1718:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|PrimitiveType|The data field's value
-[SemanticObject](./UI.xml#L1719:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String|Name of the Semantic Object
-[Action](./UI.xml#L1722:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[Mapping](./UI.xml#L1725:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1749:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|PrimitiveType|The data field's value
+[SemanticObject](./UI.xml#L1750:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String|Name of the Semantic Object
+[Action](./UI.xml#L1753:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[Mapping](./UI.xml#L1756:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -1036,19 +1056,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithNavigationPath"></a>
-## [DataFieldWithNavigationPath](./UI.xml#L1730:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-"): [DataField](#DataField)
+## [DataFieldWithNavigationPath](./UI.xml#L1761:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-"): [DataField](#DataField)
 A piece of data that allows navigating to related data
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1733:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|PrimitiveType|The data field's value
-[Target](./UI.xml#L1734:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1764:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|PrimitiveType|The data field's value
+[Target](./UI.xml#L1765:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
 
 **Applicable Annotation Terms:**
 
@@ -1059,20 +1079,20 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithUrl"></a>
-## [DataFieldWithUrl](./UI.xml#L1741:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-"): [DataField](#DataField)
+## [DataFieldWithUrl](./UI.xml#L1772:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-"): [DataField](#DataField)
 A piece of data that allows navigating to other information on the Web
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1744:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|PrimitiveType|The data field's value
-[Url](./UI.xml#L1745:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](./UI.xml#L1754:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1775:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|PrimitiveType|The data field's value
+[Url](./UI.xml#L1776:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](./UI.xml#L1785:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
 
 **Applicable Annotation Terms:**
 
@@ -1083,17 +1103,17 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithActionGroup"></a>
-## [DataFieldWithActionGroup](./UI.xml#L1760:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-"): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
+## [DataFieldWithActionGroup](./UI.xml#L1791:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-"): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1565:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1569:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1572:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1575:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1763:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|PrimitiveType|The data field's value
-[Actions](./UI.xml#L1764:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
+[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1794:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|PrimitiveType|The data field's value
+[Actions](./UI.xml#L1795:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
 
 **Applicable Annotation Terms:**
 
@@ -1104,7 +1124,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="RecommendationStateType"></a>
-## [RecommendationStateType](./UI.xml#L1802:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")
+## [RecommendationStateType](./UI.xml#L1833:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")
 **Type:** Byte
 
 Indicates whether a field contains or has a recommended value
@@ -1113,33 +1133,33 @@ Editable fields for which a recommendation has been pre-filled or that have reco
 
 Allowed Value|Description
 :------------|:----------
-[0](./UI.xml#L1809:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|regular - with human or default input, no recommendation
-[1](./UI.xml#L1813:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|highlighted - without human input and with recommendation
-[2](./UI.xml#L1817:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|warning - with human or default input and with recommendation
+[0](./UI.xml#L1840:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|regular - with human or default input, no recommendation
+[1](./UI.xml#L1844:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|highlighted - without human input and with recommendation
+[2](./UI.xml#L1848:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|warning - with human or default input and with recommendation
 
 <a name="RecommendationListType"></a>
-## [RecommendationListType](./UI.xml#L1832:~:text=<ComplexType%20Name="-,RecommendationListType,-")
+## [RecommendationListType](./UI.xml#L1863:~:text=<ComplexType%20Name="-,RecommendationListType,-")
 Reference to a recommendation list
 
 A recommendation consists of one or more values for editable fields plus a rank between 0.0 and 9.9, with 9.9 being the best recommendation.
 
 Property|Type|Description
 :-------|:---|:----------
-[CollectionPath](./UI.xml#L1837:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Resource path of a collection of recommended values
-[RankProperty](./UI.xml#L1840:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
-[Binding](./UI.xml#L1843:~:text=<ComplexType%20Name="-,RecommendationListType,-")|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
+[CollectionPath](./UI.xml#L1868:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Resource path of a collection of recommended values
+[RankProperty](./UI.xml#L1871:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
+[Binding](./UI.xml#L1874:~:text=<ComplexType%20Name="-,RecommendationListType,-")|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
 
 <a name="RecommendationBinding"></a>
-## [RecommendationBinding](./UI.xml#L1848:~:text=<ComplexType%20Name="-,RecommendationBinding,-")
+## [RecommendationBinding](./UI.xml#L1879:~:text=<ComplexType%20Name="-,RecommendationBinding,-")
 
 
 Property|Type|Description
 :-------|:---|:----------
-[LocalDataProperty](./UI.xml#L1849:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|PropertyPath|Path to editable property for which recommended values exist
-[ValueListProperty](./UI.xml#L1852:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
+[LocalDataProperty](./UI.xml#L1880:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|PropertyPath|Path to editable property for which recommended values exist
+[ValueListProperty](./UI.xml#L1883:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
 
 <a name="ActionName"></a>
-## [ActionName](./UI.xml#L1876:~:text=<TypeDefinition%20Name="-,ActionName,-")
+## [ActionName](./UI.xml#L1907:~:text=<TypeDefinition%20Name="-,ActionName,-")
 **Type:** String
 
 Name of an Action, Function, ActionImport, or FunctionImport in scope

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -759,7 +759,7 @@ Property|Type|Description
 :-------|:---|:----------
 [Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
 [Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|A single character symbol to be shown where the user can type a character
-[InputMaskRules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[Rules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
 ## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -54,7 +54,7 @@ Term|Type|Description
 [IsImage](./UI.xml#L1383:~:text=<Term%20Name="-,IsImage,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
 [MultiLineText](./UI.xml#L1394:~:text=<Term%20Name="-,MultiLineText,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
 [Placeholder](./UI.xml#L1399:~:text=<Term%20Name="-,Placeholder,-")|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode.<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
 [TextArrangement](./UI.xml#L1435:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
 [Note](./UI.xml#L1458:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
 [Importance](./UI.xml#L1511:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
@@ -759,7 +759,7 @@ Property|Type|Description
 :-------|:---|:----------
 [Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
 [Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String?|A single character symbol to be shown where the user can type a character
-[InputMaskRules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask.<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[InputMaskRules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
 ## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")
@@ -768,7 +768,7 @@ Property|Type|Description
 Property|Type|Description
 :-------|:---|:----------
 [MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
-[RegExp](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|Regular expression that defines the valid values for the mask symbol.
+[RegExp](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|Regular expression that defines the valid values for the mask symbol
 
 <a name="TextArrangementType"></a>
 ## [TextArrangementType](./UI.xml#L1443:~:text=<EnumType%20Name="-,TextArrangementType,-")

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -54,28 +54,28 @@ Term|Type|Description
 [IsImage](./UI.xml#L1383:~:text=<Term%20Name="-,IsImage,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
 [MultiLineText](./UI.xml#L1394:~:text=<Term%20Name="-,MultiLineText,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
 [Placeholder](./UI.xml#L1399:~:text=<Term%20Name="-,Placeholder,-")|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-")|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
-[TextArrangement](./UI.xml#L1435:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
-[Note](./UI.xml#L1458:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
-[Importance](./UI.xml#L1511:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
-[Hidden](./UI.xml#L1526:~:text=<Term%20Name="-,Hidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
-[IsCopyAction](./UI.xml#L1534:~:text=<Term%20Name="-,IsCopyAction,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
-[CreateHidden](./UI.xml#L1546:~:text=<Term%20Name="-,CreateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
-[UpdateHidden](./UI.xml#L1551:~:text=<Term%20Name="-,UpdateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[DeleteHidden](./UI.xml#L1556:~:text=<Term%20Name="-,DeleteHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[HiddenFilter](./UI.xml#L1561:~:text=<Term%20Name="-,HiddenFilter,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
-[AdaptationHidden](./UI.xml#L1570:~:text=<Term%20Name="-,AdaptationHidden,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
-[DataFieldDefault](./UI.xml#L1576:~:text=<Term%20Name="-,DataFieldDefault,-")|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
-[Criticality](./UI.xml#L1800:~:text=<Term%20Name="-,Criticality,-")|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
-[CriticalityCalculation](./UI.xml#L1804:~:text=<Term%20Name="-,CriticalityCalculation,-")|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
-[Emphasized](./UI.xml#L1808:~:text=<Term%20Name="-,Emphasized,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
-[OrderBy](./UI.xml#L1814:~:text=<Term%20Name="-,OrderBy,-") *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
-[ParameterDefaultValue](./UI.xml#L1820:~:text=<Term%20Name="-,ParameterDefaultValue,-")|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
-[RecommendationState](./UI.xml#L1826:~:text=<Term%20Name="-,RecommendationState,-")|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
-[RecommendationList](./UI.xml#L1856:~:text=<Term%20Name="-,RecommendationList,-")|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
-[ExcludeFromNavigationContext](./UI.xml#L1888:~:text=<Term%20Name="-,ExcludeFromNavigationContext,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
-[DoNotCheckScaleOfMeasuredQuantity](./UI.xml#L1892:~:text=<Term%20Name="-,DoNotCheckScaleOfMeasuredQuantity,-") *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
-[LeadingEntitySet](./UI.xml#L1902:~:text=<Term%20Name="-,LeadingEntitySet,-") *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
+[InputMask](./UI.xml#L1404:~:text=<Term%20Name="-,InputMask,-") *([Experimental](Common.md#Experimental))*|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[TextArrangement](./UI.xml#L1438:~:text=<Term%20Name="-,TextArrangement,-")|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
+[Note](./UI.xml#L1461:~:text=<Term%20Name="-,Note,-") *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
+[Importance](./UI.xml#L1514:~:text=<Term%20Name="-,Importance,-")|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
+[Hidden](./UI.xml#L1529:~:text=<Term%20Name="-,Hidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
+[IsCopyAction](./UI.xml#L1537:~:text=<Term%20Name="-,IsCopyAction,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
+[CreateHidden](./UI.xml#L1549:~:text=<Term%20Name="-,CreateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
+[UpdateHidden](./UI.xml#L1554:~:text=<Term%20Name="-,UpdateHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[DeleteHidden](./UI.xml#L1559:~:text=<Term%20Name="-,DeleteHidden,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[HiddenFilter](./UI.xml#L1564:~:text=<Term%20Name="-,HiddenFilter,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
+[AdaptationHidden](./UI.xml#L1573:~:text=<Term%20Name="-,AdaptationHidden,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
+[DataFieldDefault](./UI.xml#L1579:~:text=<Term%20Name="-,DataFieldDefault,-")|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
+[Criticality](./UI.xml#L1803:~:text=<Term%20Name="-,Criticality,-")|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
+[CriticalityCalculation](./UI.xml#L1807:~:text=<Term%20Name="-,CriticalityCalculation,-")|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
+[Emphasized](./UI.xml#L1811:~:text=<Term%20Name="-,Emphasized,-") *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
+[OrderBy](./UI.xml#L1817:~:text=<Term%20Name="-,OrderBy,-") *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
+[ParameterDefaultValue](./UI.xml#L1823:~:text=<Term%20Name="-,ParameterDefaultValue,-")|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
+[RecommendationState](./UI.xml#L1829:~:text=<Term%20Name="-,RecommendationState,-")|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
+[RecommendationList](./UI.xml#L1859:~:text=<Term%20Name="-,RecommendationList,-")|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
+[ExcludeFromNavigationContext](./UI.xml#L1891:~:text=<Term%20Name="-,ExcludeFromNavigationContext,-")|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
+[DoNotCheckScaleOfMeasuredQuantity](./UI.xml#L1895:~:text=<Term%20Name="-,DoNotCheckScaleOfMeasuredQuantity,-") *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
+[LeadingEntitySet](./UI.xml#L1905:~:text=<Term%20Name="-,LeadingEntitySet,-") *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
 
 <a name="HeaderInfoType"></a>
 ## [HeaderInfoType](./UI.xml#L68:~:text=<ComplexType%20Name="-,HeaderInfoType,-")
@@ -752,59 +752,59 @@ Member|Value|Description
 [LT](./UI.xml#L1345:~:text=<EnumType%20Name="-,SelectionRangeOptionType,-")|9|Less than
 
 <a name="InputMaskType"></a>
-## [InputMaskType](./UI.xml#L1412:~:text=<ComplexType%20Name="-,InputMaskType,-")
+## [InputMaskType](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-") *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Mask](./UI.xml#L1413:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
-[Placeholder](./UI.xml#L1416:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|A single character symbol to be shown where the user can type a character
-[Rules](./UI.xml#L1419:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[Mask](./UI.xml#L1415:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|The mask to be applied to the property or the parameter
+[Placeholder](./UI.xml#L1418:~:text=<ComplexType%20Name="-,InputMaskType,-")|String|A single character symbol to be shown where the user can type a character
+[Rules](./UI.xml#L1421:~:text=<ComplexType%20Name="-,InputMaskType,-")|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
-## [InputMaskRuleType](./UI.xml#L1426:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")
+## [InputMaskRuleType](./UI.xml#L1428:~:text=<ComplexType%20Name="-,InputMaskRuleType,-") *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[MaskSymbol](./UI.xml#L1427:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
-[RegExp](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|Regular expression that defines the valid values for the mask symbol
+[MaskSymbol](./UI.xml#L1430:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
+[RegExp](./UI.xml#L1433:~:text=<ComplexType%20Name="-,InputMaskRuleType,-")|String|Regular expression that defines the valid values for the mask symbol
 
 <a name="TextArrangementType"></a>
-## [TextArrangementType](./UI.xml#L1443:~:text=<EnumType%20Name="-,TextArrangementType,-")
+## [TextArrangementType](./UI.xml#L1446:~:text=<EnumType%20Name="-,TextArrangementType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[TextFirst](./UI.xml#L1444:~:text=<EnumType%20Name="-,TextArrangementType,-")|0|Text is first, followed by the code/ID (e.g. in parentheses)
-[TextLast](./UI.xml#L1447:~:text=<EnumType%20Name="-,TextArrangementType,-")|1|Code/ID is first, followed by the text (e.g. separated by a dash)
-[TextSeparate](./UI.xml#L1450:~:text=<EnumType%20Name="-,TextArrangementType,-")|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
-[TextOnly](./UI.xml#L1453:~:text=<EnumType%20Name="-,TextArrangementType,-")|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
+[TextFirst](./UI.xml#L1447:~:text=<EnumType%20Name="-,TextArrangementType,-")|0|Text is first, followed by the code/ID (e.g. in parentheses)
+[TextLast](./UI.xml#L1450:~:text=<EnumType%20Name="-,TextArrangementType,-")|1|Code/ID is first, followed by the text (e.g. separated by a dash)
+[TextSeparate](./UI.xml#L1453:~:text=<EnumType%20Name="-,TextArrangementType,-")|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
+[TextOnly](./UI.xml#L1456:~:text=<EnumType%20Name="-,TextArrangementType,-")|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
 
 <a name="NoteType"></a>
-## [NoteType](./UI.xml#L1470:~:text=<ComplexType%20Name="-,NoteType,-") *([Experimental](Common.md#Experimental))*
+## [NoteType](./UI.xml#L1473:~:text=<ComplexType%20Name="-,NoteType,-") *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](./UI.xml#L1472:~:text=<ComplexType%20Name="-,NoteType,-")|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
-[Content](./UI.xml#L1484:~:text=<ComplexType%20Name="-,NoteType,-")|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
-[Type](./UI.xml#L1500:~:text=<ComplexType%20Name="-,NoteType,-")|String|A type used for grouping notes
-[MaximalLength](./UI.xml#L1503:~:text=<ComplexType%20Name="-,NoteType,-")|Int32?|Type-specific maximal length of the content of the note
-[MultipleNotes](./UI.xml#L1506:~:text=<ComplexType%20Name="-,NoteType,-")|Boolean|Whether the type allows multiple notes for one object
+[Title](./UI.xml#L1475:~:text=<ComplexType%20Name="-,NoteType,-")|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
+[Content](./UI.xml#L1487:~:text=<ComplexType%20Name="-,NoteType,-")|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
+[Type](./UI.xml#L1503:~:text=<ComplexType%20Name="-,NoteType,-")|String|A type used for grouping notes
+[MaximalLength](./UI.xml#L1506:~:text=<ComplexType%20Name="-,NoteType,-")|Int32?|Type-specific maximal length of the content of the note
+[MultipleNotes](./UI.xml#L1509:~:text=<ComplexType%20Name="-,NoteType,-")|Boolean|Whether the type allows multiple notes for one object
 
 <a name="ImportanceType"></a>
-## [ImportanceType](./UI.xml#L1514:~:text=<EnumType%20Name="-,ImportanceType,-")
+## [ImportanceType](./UI.xml#L1517:~:text=<EnumType%20Name="-,ImportanceType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[High](./UI.xml#L1515:~:text=<EnumType%20Name="-,ImportanceType,-")|0|High importance
-[Medium](./UI.xml#L1518:~:text=<EnumType%20Name="-,ImportanceType,-")|1|Medium importance
-[Low](./UI.xml#L1521:~:text=<EnumType%20Name="-,ImportanceType,-")|2|Low importance
+[High](./UI.xml#L1518:~:text=<EnumType%20Name="-,ImportanceType,-")|0|High importance
+[Medium](./UI.xml#L1521:~:text=<EnumType%20Name="-,ImportanceType,-")|1|Medium importance
+[Low](./UI.xml#L1524:~:text=<EnumType%20Name="-,ImportanceType,-")|2|Low importance
 
 <a name="DataFieldAbstract"></a>
-## [*DataFieldAbstract*](./UI.xml#L1581:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")
+## [*DataFieldAbstract*](./UI.xml#L1584:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")
 Elementary building block that represents a piece of data and/or allows triggering an action
 
 By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the visibility, the importance and
@@ -825,10 +825,10 @@ By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[Criticality](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[CriticalityRepresentation](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[IconUrl](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Label](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[Criticality](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[CriticalityRepresentation](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[IconUrl](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
 
 **Applicable Annotation Terms:**
 
@@ -839,26 +839,26 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="CriticalityRepresentationType"></a>
-## [CriticalityRepresentationType](./UI.xml#L1612:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")
+## [CriticalityRepresentationType](./UI.xml#L1615:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[WithIcon](./UI.xml#L1613:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|0|Criticality is represented with an icon
-[WithoutIcon](./UI.xml#L1616:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|1|Criticality is represented without icon, e.g. only via text color
-[OnlyIcon](./UI.xml#L1619:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-") *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
+[WithIcon](./UI.xml#L1616:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|0|Criticality is represented with an icon
+[WithoutIcon](./UI.xml#L1619:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-")|1|Criticality is represented without icon, e.g. only via text color
+[OnlyIcon](./UI.xml#L1622:~:text=<EnumType%20Name="-,CriticalityRepresentationType,-") *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
 
 <a name="DataFieldForAnnotation"></a>
-## [DataFieldForAnnotation](./UI.xml#L1625:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [DataFieldForAnnotation](./UI.xml#L1628:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-"): [DataFieldAbstract](#DataFieldAbstract)
 A structured piece of data described by an annotation
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Target](./UI.xml#L1627:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-")|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Target](./UI.xml#L1630:~:text=<ComplexType%20Name="-,DataFieldForAnnotation,-")|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -869,7 +869,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionAbstract"></a>
-## [*DataFieldForActionAbstract*](./UI.xml#L1642:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [*DataFieldForActionAbstract*](./UI.xml#L1645:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-"): [DataFieldAbstract](#DataFieldAbstract)
 Triggers an action
 
 **Derived Types:**
@@ -878,12 +878,12 @@ Triggers an action
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Inline](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[Determining](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Inline](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[Determining](./UI.xml#L1650:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
 
 **Applicable Annotation Terms:**
 
@@ -894,21 +894,21 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForAction"></a>
-## [DataFieldForAction](./UI.xml#L1652:~:text=<ComplexType%20Name="-,DataFieldForAction,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForAction](./UI.xml#L1655:~:text=<ComplexType%20Name="-,DataFieldForAction,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers an OData action
 
 The action is NOT tied to a data value (in contrast to [DataFieldWithAction](#DataFieldWithAction)).
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[*Inline*](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[Action](./UI.xml#L1655:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
-[InvocationGrouping](./UI.xml#L1658:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[*Inline*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](./UI.xml#L1650:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[Action](./UI.xml#L1658:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[InvocationGrouping](./UI.xml#L1661:~:text=<ComplexType%20Name="-,DataFieldForAction,-")|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
 
 **Applicable Annotation Terms:**
 
@@ -919,16 +919,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="OperationGroupingType"></a>
-## [OperationGroupingType](./UI.xml#L1662:~:text=<EnumType%20Name="-,OperationGroupingType,-")
+## [OperationGroupingType](./UI.xml#L1665:~:text=<EnumType%20Name="-,OperationGroupingType,-")
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Isolated](./UI.xml#L1663:~:text=<EnumType%20Name="-,OperationGroupingType,-")|0|Invoke each action in isolation from other actions
-[ChangeSet](./UI.xml#L1666:~:text=<EnumType%20Name="-,OperationGroupingType,-")|1|Group all actions into a single change set
+[Isolated](./UI.xml#L1666:~:text=<EnumType%20Name="-,OperationGroupingType,-")|0|Invoke each action in isolation from other actions
+[ChangeSet](./UI.xml#L1669:~:text=<EnumType%20Name="-,OperationGroupingType,-")|1|Group all actions into a single change set
 
 <a name="DataFieldForIntentBasedNavigation"></a>
-## [DataFieldForIntentBasedNavigation](./UI.xml#L1671:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForIntentBasedNavigation](./UI.xml#L1674:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-"): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -937,17 +937,17 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[*Inline*](./UI.xml#L1644:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[SemanticObject](./UI.xml#L1678:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String|Name of the Semantic Object
-[Action](./UI.xml#L1681:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[NavigationAvailable](./UI.xml#L1684:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|The navigation intent is for that user with the selected context and parameters available
-[RequiresContext](./UI.xml#L1687:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|Determines whether a context needs to be passed to the target of this navigation.
-[Mapping](./UI.xml#L1690:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[*Inline*](./UI.xml#L1647:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](./UI.xml#L1650:~:text=<ComplexType%20Name="-,DataFieldForActionAbstract,-")|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[SemanticObject](./UI.xml#L1681:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String|Name of the Semantic Object
+[Action](./UI.xml#L1684:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[NavigationAvailable](./UI.xml#L1687:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|The navigation intent is for that user with the selected context and parameters available
+[RequiresContext](./UI.xml#L1690:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|Boolean|Determines whether a context needs to be passed to the target of this navigation.
+[Mapping](./UI.xml#L1693:~:text=<ComplexType%20Name="-,DataFieldForIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -958,16 +958,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionGroup"></a>
-## [DataFieldForActionGroup](./UI.xml#L1695:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-"): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
+## [DataFieldForActionGroup](./UI.xml#L1698:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-"): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Actions](./UI.xml#L1698:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-")|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Actions](./UI.xml#L1701:~:text=<ComplexType%20Name="-,DataFieldForActionGroup,-")|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
 
 **Applicable Annotation Terms:**
 
@@ -978,7 +978,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataField"></a>
-## [DataField](./UI.xml#L1703:~:text=<ComplexType%20Name="-,DataField,-"): [DataFieldAbstract](#DataFieldAbstract)
+## [DataField](./UI.xml#L1706:~:text=<ComplexType%20Name="-,DataField,-"): [DataFieldAbstract](#DataFieldAbstract)
 A piece of data
 
 **Derived Types:**
@@ -990,11 +990,11 @@ A piece of data
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1705:~:text=<ComplexType%20Name="-,DataField,-")|Untyped|The data field's value
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1708:~:text=<ComplexType%20Name="-,DataField,-")|Untyped|The data field's value
 
 **Applicable Annotation Terms:**
 
@@ -1005,19 +1005,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithAction"></a>
-## [DataFieldWithAction](./UI.xml#L1732:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
+## [DataFieldWithAction](./UI.xml#L1735:~:text=<ComplexType%20Name="-,DataFieldWithAction,-"): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
 The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1735:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|PrimitiveType|The data field's value
-[Action](./UI.xml#L1736:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1738:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|PrimitiveType|The data field's value
+[Action](./UI.xml#L1739:~:text=<ComplexType%20Name="-,DataFieldWithAction,-")|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
 
 **Applicable Annotation Terms:**
 
@@ -1028,7 +1028,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithIntentBasedNavigation"></a>
-## [DataFieldWithIntentBasedNavigation](./UI.xml#L1741:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-"): [DataField](#DataField)
+## [DataFieldWithIntentBasedNavigation](./UI.xml#L1744:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-"): [DataField](#DataField)
 A piece of data that allows triggering intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -1038,14 +1038,14 @@ This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBa
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1749:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|PrimitiveType|The data field's value
-[SemanticObject](./UI.xml#L1750:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String|Name of the Semantic Object
-[Action](./UI.xml#L1753:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[Mapping](./UI.xml#L1756:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1752:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|PrimitiveType|The data field's value
+[SemanticObject](./UI.xml#L1753:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String|Name of the Semantic Object
+[Action](./UI.xml#L1756:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[Mapping](./UI.xml#L1759:~:text=<ComplexType%20Name="-,DataFieldWithIntentBasedNavigation,-")|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -1056,19 +1056,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithNavigationPath"></a>
-## [DataFieldWithNavigationPath](./UI.xml#L1761:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-"): [DataField](#DataField)
+## [DataFieldWithNavigationPath](./UI.xml#L1764:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-"): [DataField](#DataField)
 A piece of data that allows navigating to related data
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1764:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|PrimitiveType|The data field's value
-[Target](./UI.xml#L1765:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1767:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|PrimitiveType|The data field's value
+[Target](./UI.xml#L1768:~:text=<ComplexType%20Name="-,DataFieldWithNavigationPath,-")|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
 
 **Applicable Annotation Terms:**
 
@@ -1079,20 +1079,20 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithUrl"></a>
-## [DataFieldWithUrl](./UI.xml#L1772:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-"): [DataField](#DataField)
+## [DataFieldWithUrl](./UI.xml#L1775:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-"): [DataField](#DataField)
 A piece of data that allows navigating to other information on the Web
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1775:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|PrimitiveType|The data field's value
-[Url](./UI.xml#L1776:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](./UI.xml#L1785:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1778:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|PrimitiveType|The data field's value
+[Url](./UI.xml#L1779:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](./UI.xml#L1788:~:text=<ComplexType%20Name="-,DataFieldWithUrl,-")|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
 
 **Applicable Annotation Terms:**
 
@@ -1103,17 +1103,17 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithActionGroup"></a>
-## [DataFieldWithActionGroup](./UI.xml#L1791:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-"): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
+## [DataFieldWithActionGroup](./UI.xml#L1794:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-"): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](./UI.xml#L1596:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](./UI.xml#L1600:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
-[Value](./UI.xml#L1794:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|PrimitiveType|The data field's value
-[Actions](./UI.xml#L1795:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
+[*Label*](./UI.xml#L1599:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](./UI.xml#L1603:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](./UI.xml#L1606:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](./UI.xml#L1609:~:text=<ComplexType%20Name="-,DataFieldAbstract,-")|URL?|Optional icon
+[Value](./UI.xml#L1797:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|PrimitiveType|The data field's value
+[Actions](./UI.xml#L1798:~:text=<ComplexType%20Name="-,DataFieldWithActionGroup,-")|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
 
 **Applicable Annotation Terms:**
 
@@ -1124,7 +1124,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="RecommendationStateType"></a>
-## [RecommendationStateType](./UI.xml#L1833:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")
+## [RecommendationStateType](./UI.xml#L1836:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")
 **Type:** Byte
 
 Indicates whether a field contains or has a recommended value
@@ -1133,33 +1133,33 @@ Editable fields for which a recommendation has been pre-filled or that have reco
 
 Allowed Value|Description
 :------------|:----------
-[0](./UI.xml#L1840:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|regular - with human or default input, no recommendation
-[1](./UI.xml#L1844:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|highlighted - without human input and with recommendation
-[2](./UI.xml#L1848:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|warning - with human or default input and with recommendation
+[0](./UI.xml#L1843:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|regular - with human or default input, no recommendation
+[1](./UI.xml#L1847:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|highlighted - without human input and with recommendation
+[2](./UI.xml#L1851:~:text=<TypeDefinition%20Name="-,RecommendationStateType,-")|warning - with human or default input and with recommendation
 
 <a name="RecommendationListType"></a>
-## [RecommendationListType](./UI.xml#L1863:~:text=<ComplexType%20Name="-,RecommendationListType,-")
+## [RecommendationListType](./UI.xml#L1866:~:text=<ComplexType%20Name="-,RecommendationListType,-")
 Reference to a recommendation list
 
 A recommendation consists of one or more values for editable fields plus a rank between 0.0 and 9.9, with 9.9 being the best recommendation.
 
 Property|Type|Description
 :-------|:---|:----------
-[CollectionPath](./UI.xml#L1868:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Resource path of a collection of recommended values
-[RankProperty](./UI.xml#L1871:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
-[Binding](./UI.xml#L1874:~:text=<ComplexType%20Name="-,RecommendationListType,-")|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
+[CollectionPath](./UI.xml#L1871:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Resource path of a collection of recommended values
+[RankProperty](./UI.xml#L1874:~:text=<ComplexType%20Name="-,RecommendationListType,-")|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
+[Binding](./UI.xml#L1877:~:text=<ComplexType%20Name="-,RecommendationListType,-")|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
 
 <a name="RecommendationBinding"></a>
-## [RecommendationBinding](./UI.xml#L1879:~:text=<ComplexType%20Name="-,RecommendationBinding,-")
+## [RecommendationBinding](./UI.xml#L1882:~:text=<ComplexType%20Name="-,RecommendationBinding,-")
 
 
 Property|Type|Description
 :-------|:---|:----------
-[LocalDataProperty](./UI.xml#L1880:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|PropertyPath|Path to editable property for which recommended values exist
-[ValueListProperty](./UI.xml#L1883:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
+[LocalDataProperty](./UI.xml#L1883:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|PropertyPath|Path to editable property for which recommended values exist
+[ValueListProperty](./UI.xml#L1886:~:text=<ComplexType%20Name="-,RecommendationBinding,-")|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
 
 <a name="ActionName"></a>
-## [ActionName](./UI.xml#L1907:~:text=<TypeDefinition%20Name="-,ActionName,-")
+## [ActionName](./UI.xml#L1910:~:text=<TypeDefinition%20Name="-,ActionName,-")
 **Type:** String
 
 Name of an Action, Function, ActionImport, or FunctionImport in scope

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1417,7 +1417,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
           <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
         <Property Name="InputMaskRules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
-          <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask." />
+          <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask" />
           <Annotation Term="Core.LongDescription">
             <String>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]</String>
           </Annotation>

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1402,6 +1402,7 @@ The trend is
       </Term>
 
       <Term Name="InputMask" Type="UI.InputMaskType" Nullable="false" AppliesTo="Property Parameter">
+        <Annotation Term="Common.Experimental" />
         <Annotation Term="Core.Description" String="Properties or parameters annotated with this term will get a mask in edit mode" />
         <Annotation Term="Core.LongDescription">
           <String>Input masks improve readability and help to enter data correctly. 
@@ -1410,6 +1411,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         </Annotation>
       </Term>
       <ComplexType Name="InputMaskType">
+        <Annotation Term="Common.Experimental" />
         <Property Name="Mask" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="The mask to be applied to the property or the parameter" />
         </Property>
@@ -1424,6 +1426,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         </Property>
       </ComplexType>
       <ComplexType Name="InputMaskRuleType">
+        <Annotation Term="Common.Experimental" />
         <Property Name="MaskSymbol" Type="Edm.String" MaxLength="1" Nullable="false">
           <Annotation Term="Core.Description" String="A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs" />
         </Property>

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1401,6 +1401,37 @@ The trend is
         <Annotation Term="Core.IsLanguageDependent" />
       </Term>
 
+      <Term Name="InputMask" Type="UI.InputMaskType" Nullable="false" AppliesTo="Property Parameter">
+        <Annotation Term="Core.Description" String="Properties or parameters annotated with this term will get a mask in edit mode." />
+        <Annotation Term="Core.LongDescription">
+          <String>Input masks not only improve readability, but also help to enter data correctly. 
+So, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. 
+[Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation</String>
+        </Annotation>
+      </Term>
+      <ComplexType Name="InputMaskType">
+        <Property Name="Mask" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="The mask to be applied to the property" />
+        </Property>
+        <Property Name="Placeholder" Type="Edm.String" DefaultValue="_">
+          <Annotation Term="Core.Description" String="A single character symbol that is used as a substitute." />
+        </Property>
+        <Property Name="InputMaskRule" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
+          <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask." />
+          <Annotation Term="Core.LongDescription">
+            <String>The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]</String>
+          </Annotation>
+        </Property>
+      </ComplexType>
+      <ComplexType Name="InputMaskRuleType">
+        <Property Name="MaskSymbol" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="The character in the mask that should be validated." />
+        </Property>
+        <Property Name="Rule" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="The rule that defines the valid values for the mask symbol as regular expression." />
+        </Property>
+      </ComplexType>
+
       <Term Name="TextArrangement" Type="UI.TextArrangementType" Nullable="false" AppliesTo="Annotation EntityType">
         <Annotation Term="Core.Description" String="Describes the arrangement of a code or ID value and its text" />
         <Annotation Term="Core.LongDescription">

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1404,19 +1404,19 @@ The trend is
       <Term Name="InputMask" Type="UI.InputMaskType" Nullable="false" AppliesTo="Property Parameter">
         <Annotation Term="Core.Description" String="Properties or parameters annotated with this term will get a mask in edit mode." />
         <Annotation Term="Core.LongDescription">
-          <String>Input masks not only improve readability, but also help to enter data correctly. 
-So, masks can be especially useful for input fields that have a fixed pattern, e.g. international bank account numbers or social security numbers. 
+          <String>Input masks improve readability and help to enter data correctly. 
+So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. 
 [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation</String>
         </Annotation>
       </Term>
       <ComplexType Name="InputMaskType">
         <Property Name="Mask" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description" String="The mask to be applied to the property" />
+          <Annotation Term="Core.Description" String="The mask to be applied to the property or the parameter" />
         </Property>
         <Property Name="Placeholder" Type="Edm.String" DefaultValue="_">
           <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
-        <Property Name="InputMaskRule" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
+        <Property Name="InputMaskRules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
           <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask." />
           <Annotation Term="Core.LongDescription">
             <String>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]</String>
@@ -1427,8 +1427,8 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         <Property Name="MaskSymbol" Type="Edm.String" MaxLength="1" Nullable="false">
           <Annotation Term="Core.Description" String="A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs" />
         </Property>
-        <Property Name="Rule" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description" String="The rule that defines the valid values for the mask symbol as regular expression." />
+        <Property Name="RegExp" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="Regular expression that defines the valid values for the mask symbol." />
         </Property>
       </ComplexType>
 

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1414,7 +1414,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
           <Annotation Term="Core.Description" String="The mask to be applied to the property" />
         </Property>
         <Property Name="Placeholder" Type="Edm.String" DefaultValue="_">
-          <Annotation Term="Core.Description" String="A single character symbol that is used as a substitute." />
+          <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
         <Property Name="InputMaskRule" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
           <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask." />

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1413,7 +1413,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         <Property Name="Mask" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="The mask to be applied to the property or the parameter" />
         </Property>
-        <Property Name="Placeholder" Type="Edm.String" DefaultValue="_">
+        <Property Name="Placeholder" Type="Edm.String" MaxLength="1" Nullable="false" DefaultValue="_">
           <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
         <Property Name="InputMaskRules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1424,8 +1424,8 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         </Property>
       </ComplexType>
       <ComplexType Name="InputMaskRuleType">
-        <Property Name="MaskSymbol" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description" String="The character in the mask that should be validated." />
+        <Property Name="MaskSymbol" Type="Edm.String" MaxLength="1" Nullable="false">
+          <Annotation Term="Core.Description" String="A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs" />
         </Property>
         <Property Name="Rule" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="The rule that defines the valid values for the mask symbol as regular expression." />

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1402,7 +1402,7 @@ The trend is
       </Term>
 
       <Term Name="InputMask" Type="UI.InputMaskType" Nullable="false" AppliesTo="Property Parameter">
-        <Annotation Term="Core.Description" String="Properties or parameters annotated with this term will get a mask in edit mode." />
+        <Annotation Term="Core.Description" String="Properties or parameters annotated with this term will get a mask in edit mode" />
         <Annotation Term="Core.LongDescription">
           <String>Input masks improve readability and help to enter data correctly. 
 So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. 

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1428,7 +1428,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
           <Annotation Term="Core.Description" String="A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs" />
         </Property>
         <Property Name="RegExp" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description" String="Regular expression that defines the valid values for the mask symbol." />
+          <Annotation Term="Core.Description" String="Regular expression that defines the valid values for the mask symbol" />
         </Property>
       </ComplexType>
 

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1419,7 +1419,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         <Property Name="InputMaskRule" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
           <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask." />
           <Annotation Term="Core.LongDescription">
-            <String>The following rules are defined as default and don't need to be listed here: * = [.], C = [a-zA-Z], 9 = [0-9]</String>
+            <String>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]</String>
           </Annotation>
         </Property>
       </ComplexType>

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1416,7 +1416,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         <Property Name="Placeholder" Type="Edm.String" MaxLength="1" Nullable="false" DefaultValue="_">
           <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
-        <Property Name="InputMaskRules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
+        <Property Name="Rules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">
           <Annotation Term="Core.Description" String="Rules that define valid values for one symbol in the mask" />
           <Annotation Term="Core.LongDescription">
             <String>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]</String>


### PR DESCRIPTION
New term UI.InputMask was added along with a simple example. I'm still waiting for more sophisticated examples from the application developers requesting this feature.
Idea is to have a defaultset of rules for mask symbols like "*", "C", "9", but give the chance to define own rules for their masks. 