### PR TITLE
Rename property InputMask.Placeholder

### DIFF
--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -1261,7 +1261,7 @@
       "$Kind": "ComplexType",
       "@Common.Experimental": true,
       "Mask": { "@Core.Description": "The mask to be applied to the property or the parameter" },
-      "Placeholder": {
+      "PlaceholderSymbol": {
         "$MaxLength": 1,
         "$DefaultValue": "_",
         "@Core.Description": "A single character symbol to be shown where the user can type a character"

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -758,7 +758,7 @@ Member|Value|Description
 Property|Type|Description
 :-------|:---|:----------
 [Mask](UI.xml#L1415)|String|The mask to be applied to the property or the parameter
-[Placeholder](UI.xml#L1418)|String|A single character symbol to be shown where the user can type a character
+[PlaceholderSymbol](UI.xml#L1418)|String|A single character symbol to be shown where the user can type a character
 [Rules](UI.xml#L1421)|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -1415,7 +1415,7 @@ So, masks can be especially useful for input fields that have a fixed pattern, e
         <Property Name="Mask" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="The mask to be applied to the property or the parameter" />
         </Property>
-        <Property Name="Placeholder" Type="Edm.String" MaxLength="1" Nullable="false" DefaultValue="_">
+        <Property Name="PlaceholderSymbol" Type="Edm.String" MaxLength="1" Nullable="false" DefaultValue="_">
           <Annotation Term="Core.Description" String="A single character symbol to be shown where the user can type a character" />
         </Property>
         <Property Name="Rules" Type="Collection(UI.InputMaskRuleType)" Nullable="false">


### PR DESCRIPTION
Feedback from developers and app developers indicates that the property name might be misleading (maybe also due the term Placeholder, which is in the vocabulary right above the term InputMask). Proposal was to use PlaceholderSymbol. Looking forward to your feedback.