### PR TITLE
Hierarchical line items

### DIFF
--- a/examples/UI.ApplyRecursiveHierarchy-sample.json
+++ b/examples/UI.ApplyRecursiveHierarchy-sample.json
@@ -43,9 +43,7 @@
         "@UI.PresentationVariant": {
           "Visualizations": ["UI.LineItem#useHierarchy"],
           "RecursiveHierarchyQualifier": "myHierarchyQualifier"
-        },
-        "@UI.LineItem#useHierarchy@UI.ApplyRecursiveHierarchy": "myHierarchyQualifier",
-        "@UI.HierarchicalLineItem#useHierarchy": "myHierarchicalQualifier"
+        }
       }
     }
   },

--- a/examples/UI.ApplyRecursiveHierarchy-sample.json
+++ b/examples/UI.ApplyRecursiveHierarchy-sample.json
@@ -1,0 +1,53 @@
+{
+  "$Version": "4.0",
+  "$Reference": {
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Core.V1", "$Alias": "Core" }]
+    },
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Aggregation.V1", "$Alias": "Aggregation" }]
+    },
+    "https://sap.github.io/odata-vocabularies/vocabularies/UI.json": {
+      "$Include": [{ "$Namespace": "com.sap.vocabularies.UI.v1", "$Alias": "UI" }]
+    }
+  },
+  "Examples": {
+    "container": {
+      "$Kind": "EntityContainer",
+      "HierarchySet": { "$Collection": true, "$Type": "Examples.Hierarchy_Type" }
+    },
+    "Hierarchy_Type": {
+      "$Kind": "EntityType",
+      "$Key": ["ID"],
+      "ID": { "$MaxLength": 10 },
+      "StatusText": { "$Nullable": true, "$MaxLength": 30 },
+      "Node": { "$Type": "Edm.Guid" },
+      "to_Parent": { "$Kind": "NavigationProperty", "$Type": "Hierarchy_Type", "$Nullable": true }
+    },
+    "$Annotations": {
+      "Examples.Hierarchy_Type": {
+        "@Aggregation.RecursiveHierarchy#myHierarchyQualifier": {
+          "Node": "Node",
+          "ParentNavigationProperty": "to_Parent"
+        },
+        "@UI.LineItem#useHierarchy": [
+          {
+            "@odata.type": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml#UI.DataField",
+            "Value": { "$Path": "ID" }
+          },
+          {
+            "@odata.type": "https://sap.github.io/odata-vocabularies/vocabularies/UI.xml#UI.DataField",
+            "Value": { "$Path": "StatusText" }
+          }
+        ],
+        "@UI.PresentationVariant": {
+          "Visualizations": ["UI.LineItem#useHierarchy"],
+          "RecursiveHierarchyQualifier": "myHierarchyQualifier"
+        },
+        "@UI.LineItem#useHierarchy@UI.ApplyRecursiveHierarchy": "myHierarchyQualifier",
+        "@UI.HierarchicalLineItem#useHierarchy": "myHierarchicalQualifier"
+      }
+    }
+  },
+  "$EntityContainer": "Examples.container"
+}

--- a/examples/UI.ApplyRecursiveHierarchy-sample.xml
+++ b/examples/UI.ApplyRecursiveHierarchy-sample.xml
@@ -37,7 +37,6 @@
           </Record>
         </Annotation>
 
-        <!-- Variant 1 - PresentationVariant -->
         <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
           <Collection>
             <Record Type="UI.DataField">
@@ -58,32 +57,6 @@
             <PropertyValue Property="RecursiveHierarchyQualifier" String="myHierarchyQualifier" />
           </Record>
         </Annotation>
-
-        <!-- Variant 2 - Term UI.ApplyRecursiveHierarchy that can be applied to UI.LineItem -->
-        <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
-          <Annotation Term="UI.ApplyRecursiveHierarchy" String="myHierarchyQualifier" />
-          <Collection>
-            <Record Type="UI.DataField">
-              <PropertyValue Property="Value" Path="ID" />
-            </Record>
-            <Record Type="UI.DataField">
-              <PropertyValue Property="Value" Path="StatusText" />
-            </Record>
-          </Collection>
-        </Annotation>
-
-        <!-- Variant 3 - Term UI.HierarchicalLineItem that has UI.LineItem as a BaseTerm -->  
-        <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
-          <Collection>
-            <Record Type="UI.DataField">
-              <PropertyValue Property="Value" Path="ID" />
-            </Record>
-            <Record Type="UI.DataField">
-              <PropertyValue Property="Value" Path="StatusText" />
-            </Record>
-          </Collection>
-        </Annotation>
-        <Annotation Term="UI.HierarchicalLineItem" Qualifier="useHierarchy" String="myHierarchicalQualifier" />  
 
       </Annotations>
 

--- a/examples/UI.ApplyRecursiveHierarchy-sample.xml
+++ b/examples/UI.ApplyRecursiveHierarchy-sample.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx Version="4.0" xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Namespace="Org.OData.Core.V1" Alias="Core" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Aggregation.V1.xml">
+    <edmx:Include Namespace="Org.OData.Aggregation.V1" Alias="Aggregation" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/UI.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.UI.v1" Alias="UI" />
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema Namespace="Examples" xmlns="http://docs.oasis-open.org/odata/ns/edm">
+      
+      <EntityContainer Name="container">
+        <EntitySet Name="HierarchySet" EntityType="Examples.Hierarchy_Type" />
+      </EntityContainer>
+
+      <EntityType Name="Hierarchy_Type">
+        <Key>
+          <PropertyRef Name="ID" />
+        </Key>
+        <Property Name="ID" Type="Edm.String" Nullable="false" MaxLength="10" />
+        <Property Name="StatusText" Type="Edm.String" MaxLength="30" />
+        <Property Name="Node" Type="Edm.Guid" Nullable="false" />
+        <NavigationProperty Name="to_Parent" Type="Hierarchy_Type" />
+        <!-- ... and a lot more -->
+      </EntityType>
+
+      <Annotations Target="Examples.Hierarchy_Type">
+
+        <Annotation Term="Aggregation.RecursiveHierarchy" Qualifier="myHierarchyQualifier">
+          <Record>
+            <PropertyValue Property="Node" PropertyPath="Node" />
+            <PropertyValue Property="ParentNavigationProperty" NavigationPropertyPath="to_Parent" />
+          </Record>
+        </Annotation>
+
+        <!-- Variant 1 - PresentationVariant -->
+        <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ID" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="StatusText" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.PresentationVariant">
+          <Record>
+            <PropertyValue Property="Visualizations">
+              <Collection>
+                <AnnotationPath>UI.LineItem#useHierarchy</AnnotationPath>
+              </Collection>
+            </PropertyValue>
+            <PropertyValue Property="RecursiveHierarchyQualifier" String="myHierarchyQualifier" />
+          </Record>
+        </Annotation>
+
+        <!-- Variant 2 - Term UI.ApplyRecursiveHierarchy that can be applied to UI.LineItem -->
+        <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
+          <Annotation Term="UI.ApplyRecursiveHierarchy" String="myHierarchyQualifier" />
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ID" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="StatusText" />
+            </Record>
+          </Collection>
+        </Annotation>
+
+        <!-- Variant 3 - Term UI.HierarchicalLineItem that has UI.LineItem as a BaseTerm -->  
+        <Annotation Term="UI.LineItem" Qualifier="useHierarchy">
+          <Collection>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="ID" />
+            </Record>
+            <Record Type="UI.DataField">
+              <PropertyValue Property="Value" Path="StatusText" />
+            </Record>
+          </Collection>
+        </Annotation>
+        <Annotation Term="UI.HierarchicalLineItem" Qualifier="useHierarchy" String="myHierarchicalQualifier" />  
+
+      </Annotations>
+
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -123,6 +123,26 @@
       "@Core.Description": "Collection of data fields for representation in a table or list",
       "@UI.ThingPerspective": true
     },
+    "ApplyRecursiveHierarchy": {
+      "$Kind": "Term",
+      "$Type": "Aggregation.HierarchyQualifier",
+      "$Nullable": true,
+      "$AppliesTo": ["Annotation"],
+      "@Common.Experimental": true,
+      "@Core.RequiresType": "UI.LineItem",
+      "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to a UI.LineItem",
+      "@Core.LongDescription": "Variant 2 for hierarchical LineItems"
+    },
+    "HierarchicalLineItem": {
+      "$Kind": "Term",
+      "$Type": "Aggregation.HierarchyQualifier",
+      "$Nullable": true,
+      "$AppliesTo": ["EntityType"],
+      "$BaseTerm": "UI.LineItem",
+      "@Common.Experimental": true,
+      "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier",
+      "@Core.LongDescription": "Variant 3 for hierarchical LineItems"
+    },
     "StatusInfo": {
       "$Kind": "Term",
       "$Collection": true,
@@ -1042,6 +1062,13 @@
         "$Type": "Edm.AnnotationPath",
         "@Core.Description": "Lists available visualization types. Currently supported types are `UI.LineItem`, `UI.Chart`, and `UI.DataPoint`.\n              For each type, no more than a single annotation is meaningful. Multiple instances of the same visualization type\n              shall be modeled with different presentation variants.\n              A reference to `UI.Lineitem` should always be part of the collection (least common denominator for renderers).\n              The first entry of the collection is the default visualization.\n            ",
         "@Validation.AllowedTerms": ["UI.Chart", "UI.DataPoint", "UI.LineItem"]
+      },
+      "RecursiveHierarchyQualifier": {
+        "$Type": "Aggregation.HierarchyQualifier",
+        "$Nullable": true,
+        "@Common.Experimental": true,
+        "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to the Visualization",
+        "@Core.LongDescription": "Variant 1 for hierarchical LineItems"
       },
       "RequestAtLeast": {
         "$Collection": true,

--- a/vocabularies/UI.json
+++ b/vocabularies/UI.json
@@ -123,26 +123,6 @@
       "@Core.Description": "Collection of data fields for representation in a table or list",
       "@UI.ThingPerspective": true
     },
-    "ApplyRecursiveHierarchy": {
-      "$Kind": "Term",
-      "$Type": "Aggregation.HierarchyQualifier",
-      "$Nullable": true,
-      "$AppliesTo": ["Annotation"],
-      "@Common.Experimental": true,
-      "@Core.RequiresType": "UI.LineItem",
-      "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to a UI.LineItem",
-      "@Core.LongDescription": "Variant 2 for hierarchical LineItems"
-    },
-    "HierarchicalLineItem": {
-      "$Kind": "Term",
-      "$Type": "Aggregation.HierarchyQualifier",
-      "$Nullable": true,
-      "$AppliesTo": ["EntityType"],
-      "$BaseTerm": "UI.LineItem",
-      "@Common.Experimental": true,
-      "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier",
-      "@Core.LongDescription": "Variant 3 for hierarchical LineItems"
-    },
     "StatusInfo": {
       "$Kind": "Term",
       "$Collection": true,
@@ -1067,8 +1047,7 @@
         "$Type": "Aggregation.HierarchyQualifier",
         "$Nullable": true,
         "@Common.Experimental": true,
-        "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to the Visualization",
-        "@Core.LongDescription": "Variant 1 for hierarchical LineItems"
+        "@Core.Description": "Qualifier of the recursive hierarchy that should be applied to the Visualization"
       },
       "RequestAtLeast": {
         "$Collection": true,

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -24,58 +24,60 @@ Term|Type|Description
 [Identification](UI.xml#L115)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="Identification"></a>Collection of fields identifying the object
 [Badge](UI.xml#L120)|[BadgeType](#BadgeType)|<a name="Badge"></a>Information usually displayed in the form of a business card
 [LineItem](UI.xml#L147)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="LineItem"></a>Collection of data fields for representation in a table or list
-[StatusInfo](UI.xml#L152)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="StatusInfo"></a>Collection of data fields describing the status of an entity
-[FieldGroup](UI.xml#L157)|[FieldGroupType](#FieldGroupType)|<a name="FieldGroup"></a>Group of fields with an optional label
-[ConnectedFields](UI.xml#L171)|[ConnectedFieldsType](#ConnectedFieldsType)|<a name="ConnectedFields"></a>Group of semantically connected fields with a representation template and an optional label ([Example](UI.xml#L173))
-[GeoLocations](UI.xml#L236)|\[[GeoLocationType](#GeoLocationType)\]|<a name="GeoLocations"></a>Collection of geographic locations
-[GeoLocation](UI.xml#L240)|[GeoLocationType](#GeoLocationType)|<a name="GeoLocation"></a>Geographic location
-[Contacts](UI.xml#L260)|\[AnnotationPath\]|<a name="Contacts"></a>Collection of contacts<br>Each collection item MUST reference an annotation of a Communication.Contact<br>Allowed terms:<ul><li>[Contact](Communication.md#Contact)</li></ul>
-[MediaResource](UI.xml#L271)|[MediaResourceType](#MediaResourceType)|<a name="MediaResource"></a>Properties that describe a media resource<br>Either `Url` or `Stream` MUST be present, and never both.
-[DataPoint](UI.xml#L351)|[DataPointType](#DataPointType)|<a name="DataPoint"></a>Visualization of a single point of data, typically a number; may also be textual, e.g. a status value
-[KPI](UI.xml#L659)|[KPIType](#KPIType)|<a name="KPI"></a>A Key Performance Indicator (KPI) bundles a SelectionVariant and a DataPoint, and provides details for progressive disclosure
-[Chart](UI.xml#L705)|[ChartDefinitionType](#ChartDefinitionType)|<a name="Chart"></a>Visualization of multiple data points
-[ValueCriticality](UI.xml#L929) *([Experimental](Common.md#Experimental))*|\[[ValueCriticalityType](#ValueCriticalityType)\]|<a name="ValueCriticality"></a>Assign criticalities to primitive values. This information can be used for semantic coloring.
-[CriticalityLabels](UI.xml#L942) *([Experimental](Common.md#Experimental))*|\[[CriticalityLabelType](#CriticalityLabelType)\]|<a name="CriticalityLabels"></a>Assign labels to criticalities. This information can be used for semantic coloring. When applied to a property, a label for a criticality must be provided, if more than one value of the annotated property has been assigned to the same criticality. There must be no more than one label per criticality.
-[SelectionFields](UI.xml#L963)|\[PropertyPath\]|<a name="SelectionFields"></a>Properties that might be relevant for filtering a collection of entities of this type
-[Facets](UI.xml#L971)|\[[Facet](#Facet)\]|<a name="Facets"></a>Collection of facets
-[HeaderFacets](UI.xml#L975)|\[[Facet](#Facet)\]|<a name="HeaderFacets"></a>Facets for additional object header information
-[QuickViewFacets](UI.xml#L979)|\[[Facet](#Facet)\]|<a name="QuickViewFacets"></a>Facets that may be used for a quick overview of the object
-[QuickCreateFacets](UI.xml#L983)|\[[Facet](#Facet)\]|<a name="QuickCreateFacets"></a>Facets that may be used for a (quick) create of the object
-[FilterFacets](UI.xml#L987)|\[[ReferenceFacet](#ReferenceFacet)\]|<a name="FilterFacets"></a>Facets that reference UI.FieldGroup annotations to group filterable fields
-[SelectionPresentationVariant](UI.xml#L1060)|[SelectionPresentationVariantType](#SelectionPresentationVariantType)|<a name="SelectionPresentationVariant"></a>A SelectionPresentationVariant bundles a Selection Variant and a Presentation Variant
-[PresentationVariant](UI.xml#L1084)|[PresentationVariantType](#PresentationVariantType)|<a name="PresentationVariant"></a>Defines how the result of a queried collection of entities is shaped and how this result is displayed
-[SelectionVariant](UI.xml#L1197)|[SelectionVariantType](#SelectionVariantType)|<a name="SelectionVariant"></a>A SelectionVariant denotes a combination of parameters and filters to query the annotated entity set
-[ThingPerspective](UI.xml#L1353)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ThingPerspective"></a>The annotated term is a Thing Perspective
-[IsSummary](UI.xml#L1356)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsSummary"></a>This Facet and all included Facets are the summary of the thing. At most one Facet of a thing can be tagged with this term
-[PartOfPreview](UI.xml#L1360)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="PartOfPreview"></a>This record and all included structural elements are part of the Thing preview<br>This term can be applied e.g. to UI.Facet and UI.DataField
-[Map](UI.xml#L1364)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Map"></a>Target MUST reference a UI.GeoLocation, Communication.Address or a collection of these
-[Gallery](UI.xml#L1368)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Gallery"></a>Target MUST reference a UI.MediaResource
-[IsImageURL](UI.xml#L1373)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImageURL"></a>Properties and terms annotated with this term MUST contain a valid URL referencing an resource with a MIME type image<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
-[IsImage](UI.xml#L1383) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
-[MultiLineText](UI.xml#L1394)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
-[Placeholder](UI.xml#L1399)|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[InputMask](UI.xml#L1404) *([Experimental](Common.md#Experimental))*|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
-[TextArrangement](UI.xml#L1438)|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
-[Note](UI.xml#L1461) *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
-[Importance](UI.xml#L1514)|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
-[Hidden](UI.xml#L1529)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
-[IsCopyAction](UI.xml#L1537) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
-[CreateHidden](UI.xml#L1549)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
-[UpdateHidden](UI.xml#L1554)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[DeleteHidden](UI.xml#L1559)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[HiddenFilter](UI.xml#L1564)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
-[AdaptationHidden](UI.xml#L1573) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
-[DataFieldDefault](UI.xml#L1579)|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
-[Criticality](UI.xml#L1804)|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
-[CriticalityCalculation](UI.xml#L1808)|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
-[Emphasized](UI.xml#L1812) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
-[OrderBy](UI.xml#L1818) *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
-[ParameterDefaultValue](UI.xml#L1824)|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
-[RecommendationState](UI.xml#L1830)|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
-[RecommendationList](UI.xml#L1860)|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
-[ExcludeFromNavigationContext](UI.xml#L1892)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
-[DoNotCheckScaleOfMeasuredQuantity](UI.xml#L1896) *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
-[LeadingEntitySet](UI.xml#L1906) *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
+[ApplyRecursiveHierarchy](UI.xml#L152) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|<a name="ApplyRecursiveHierarchy"></a>Qualifier of the recursive hierarchy that should be applied to a UI.LineItem<br>Variant 2 for hierarchical LineItems
+[HierarchicalLineItem](UI.xml#L161) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|<a name="HierarchicalLineItem"></a>Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier<br>Variant 3 for hierarchical LineItems
+[StatusInfo](UI.xml#L169)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="StatusInfo"></a>Collection of data fields describing the status of an entity
+[FieldGroup](UI.xml#L174)|[FieldGroupType](#FieldGroupType)|<a name="FieldGroup"></a>Group of fields with an optional label
+[ConnectedFields](UI.xml#L188)|[ConnectedFieldsType](#ConnectedFieldsType)|<a name="ConnectedFields"></a>Group of semantically connected fields with a representation template and an optional label ([Example](UI.xml#L190))
+[GeoLocations](UI.xml#L253)|\[[GeoLocationType](#GeoLocationType)\]|<a name="GeoLocations"></a>Collection of geographic locations
+[GeoLocation](UI.xml#L257)|[GeoLocationType](#GeoLocationType)|<a name="GeoLocation"></a>Geographic location
+[Contacts](UI.xml#L277)|\[AnnotationPath\]|<a name="Contacts"></a>Collection of contacts<br>Each collection item MUST reference an annotation of a Communication.Contact<br>Allowed terms:<ul><li>[Contact](Communication.md#Contact)</li></ul>
+[MediaResource](UI.xml#L288)|[MediaResourceType](#MediaResourceType)|<a name="MediaResource"></a>Properties that describe a media resource<br>Either `Url` or `Stream` MUST be present, and never both.
+[DataPoint](UI.xml#L368)|[DataPointType](#DataPointType)|<a name="DataPoint"></a>Visualization of a single point of data, typically a number; may also be textual, e.g. a status value
+[KPI](UI.xml#L676)|[KPIType](#KPIType)|<a name="KPI"></a>A Key Performance Indicator (KPI) bundles a SelectionVariant and a DataPoint, and provides details for progressive disclosure
+[Chart](UI.xml#L722)|[ChartDefinitionType](#ChartDefinitionType)|<a name="Chart"></a>Visualization of multiple data points
+[ValueCriticality](UI.xml#L946) *([Experimental](Common.md#Experimental))*|\[[ValueCriticalityType](#ValueCriticalityType)\]|<a name="ValueCriticality"></a>Assign criticalities to primitive values. This information can be used for semantic coloring.
+[CriticalityLabels](UI.xml#L959) *([Experimental](Common.md#Experimental))*|\[[CriticalityLabelType](#CriticalityLabelType)\]|<a name="CriticalityLabels"></a>Assign labels to criticalities. This information can be used for semantic coloring. When applied to a property, a label for a criticality must be provided, if more than one value of the annotated property has been assigned to the same criticality. There must be no more than one label per criticality.
+[SelectionFields](UI.xml#L980)|\[PropertyPath\]|<a name="SelectionFields"></a>Properties that might be relevant for filtering a collection of entities of this type
+[Facets](UI.xml#L987)|\[[Facet](#Facet)\]|<a name="Facets"></a>Collection of facets
+[HeaderFacets](UI.xml#L991)|\[[Facet](#Facet)\]|<a name="HeaderFacets"></a>Facets for additional object header information
+[QuickViewFacets](UI.xml#L995)|\[[Facet](#Facet)\]|<a name="QuickViewFacets"></a>Facets that may be used for a quick overview of the object
+[QuickCreateFacets](UI.xml#L999)|\[[Facet](#Facet)\]|<a name="QuickCreateFacets"></a>Facets that may be used for a (quick) create of the object
+[FilterFacets](UI.xml#L1003)|\[[ReferenceFacet](#ReferenceFacet)\]|<a name="FilterFacets"></a>Facets that reference UI.FieldGroup annotations to group filterable fields
+[SelectionPresentationVariant](UI.xml#L1076)|[SelectionPresentationVariantType](#SelectionPresentationVariantType)|<a name="SelectionPresentationVariant"></a>A SelectionPresentationVariant bundles a Selection Variant and a Presentation Variant
+[PresentationVariant](UI.xml#L1100)|[PresentationVariantType](#PresentationVariantType)|<a name="PresentationVariant"></a>Defines how the result of a queried collection of entities is shaped and how this result is displayed
+[SelectionVariant](UI.xml#L1220)|[SelectionVariantType](#SelectionVariantType)|<a name="SelectionVariant"></a>A SelectionVariant denotes a combination of parameters and filters to query the annotated entity set
+[ThingPerspective](UI.xml#L1376)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ThingPerspective"></a>The annotated term is a Thing Perspective
+[IsSummary](UI.xml#L1379)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsSummary"></a>This Facet and all included Facets are the summary of the thing. At most one Facet of a thing can be tagged with this term
+[PartOfPreview](UI.xml#L1383)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="PartOfPreview"></a>This record and all included structural elements are part of the Thing preview<br>This term can be applied e.g. to UI.Facet and UI.DataField
+[Map](UI.xml#L1387)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Map"></a>Target MUST reference a UI.GeoLocation, Communication.Address or a collection of these
+[Gallery](UI.xml#L1391)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Gallery"></a>Target MUST reference a UI.MediaResource
+[IsImageURL](UI.xml#L1396)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImageURL"></a>Properties and terms annotated with this term MUST contain a valid URL referencing an resource with a MIME type image<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
+[IsImage](UI.xml#L1406) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
+[MultiLineText](UI.xml#L1417)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
+[Placeholder](UI.xml#L1422)|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
+[InputMask](UI.xml#L1427) *([Experimental](Common.md#Experimental))*|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[TextArrangement](UI.xml#L1461)|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
+[Note](UI.xml#L1484) *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
+[Importance](UI.xml#L1537)|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
+[Hidden](UI.xml#L1552)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
+[IsCopyAction](UI.xml#L1560) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
+[CreateHidden](UI.xml#L1572)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
+[UpdateHidden](UI.xml#L1577)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[DeleteHidden](UI.xml#L1582)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[HiddenFilter](UI.xml#L1587)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
+[AdaptationHidden](UI.xml#L1596) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
+[DataFieldDefault](UI.xml#L1602)|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
+[Criticality](UI.xml#L1827)|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
+[CriticalityCalculation](UI.xml#L1831)|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
+[Emphasized](UI.xml#L1835) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
+[OrderBy](UI.xml#L1841) *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
+[ParameterDefaultValue](UI.xml#L1847)|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
+[RecommendationState](UI.xml#L1853)|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
+[RecommendationList](UI.xml#L1883)|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
+[ExcludeFromNavigationContext](UI.xml#L1915)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
+[DoNotCheckScaleOfMeasuredQuantity](UI.xml#L1919) *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
+[LeadingEntitySet](UI.xml#L1929) *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
 
 <a name="HeaderInfoType"></a>
 ## [HeaderInfoType](UI.xml#L68)
@@ -106,137 +108,137 @@ Property|Type|Description
 [SecondaryInfo](UI.xml#L142)|[DataField?](#DataField)|Additional information on the business card
 
 <a name="FieldGroupType"></a>
-## [FieldGroupType](UI.xml#L161)
+## [FieldGroupType](UI.xml#L178)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L162)|String?|Label for the field group
-[Data](UI.xml#L166)|\[[DataFieldAbstract](#DataFieldAbstract)\]|Collection of data fields
+[Label](UI.xml#L179)|String?|Label for the field group
+[Data](UI.xml#L183)|\[[DataFieldAbstract](#DataFieldAbstract)\]|Collection of data fields
 
 <a name="ConnectedFieldsType"></a>
-## [ConnectedFieldsType](UI.xml#L198)
+## [ConnectedFieldsType](UI.xml#L215)
 Group of semantically connected fields with a representation template and an optional label
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L200)|String?|Label for the connected fields
-[Template](UI.xml#L204)|String|Template for representing the connected fields<br>Template variables are identifiers enclosed in curly braces, e.g. `{MaterialName} - {MaterialClassName}`. The `Data` collection assigns values to the template variables.
-[Data](UI.xml#L209)|[Dictionary](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Dictionary)|Dictionary of template variables<br>Each template variable used in `Template` must be assigned a value here. The value must be of type [DataFieldAbstract](#DataFieldAbstract)
+[Label](UI.xml#L217)|String?|Label for the connected fields
+[Template](UI.xml#L221)|String|Template for representing the connected fields<br>Template variables are identifiers enclosed in curly braces, e.g. `{MaterialName} - {MaterialClassName}`. The `Data` collection assigns values to the template variables.
+[Data](UI.xml#L226)|[Dictionary](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Dictionary)|Dictionary of template variables<br>Each template variable used in `Template` must be assigned a value here. The value must be of type [DataFieldAbstract](#DataFieldAbstract)
 
 <a name="GeoLocationType"></a>
-## [GeoLocationType](UI.xml#L244)
+## [GeoLocationType](UI.xml#L261)
 Properties that define a geographic location
 
 Property|Type|Description
 :-------|:---|:----------
-[Latitude](UI.xml#L246)|Double?|Geographic latitude
-[Longitude](UI.xml#L249)|Double?|Geographic longitude
-[Location](UI.xml#L252)|GeographyPoint?|A point in a round-earth coordinate system
-[Address](UI.xml#L255)|[AddressType?](Communication.md#AddressType)|vCard-style address
+[Latitude](UI.xml#L263)|Double?|Geographic latitude
+[Longitude](UI.xml#L266)|Double?|Geographic longitude
+[Location](UI.xml#L269)|GeographyPoint?|A point in a round-earth coordinate system
+[Address](UI.xml#L272)|[AddressType?](Communication.md#AddressType)|vCard-style address
 
 <a name="MediaResourceType"></a>
-## [MediaResourceType](UI.xml#L276)
+## [MediaResourceType](UI.xml#L293)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Url](UI.xml#L277)|URL?|URL of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[Stream](UI.xml#L286) *([Experimental](Common.md#Experimental))*|Stream?|Stream of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[ContentType](UI.xml#L295)|MediaType?|Content type, such as application/pdf, video/x-flv, image/jpeg
-[ByteSize](UI.xml#L299)|Int64?|Resource size in bytes
-[ChangedAt](UI.xml#L302)|DateTimeOffset?|Date of last change
-[Thumbnail](UI.xml#L305)|[ImageType?](#ImageType)|Thumbnail image
-[Title](UI.xml#L308)|[DataField?](#DataField)|Resource title
-[Description](UI.xml#L311)|[DataField?](#DataField)|Resource description
+[Url](UI.xml#L294)|URL?|URL of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[Stream](UI.xml#L303) *([Experimental](Common.md#Experimental))*|Stream?|Stream of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[ContentType](UI.xml#L312)|MediaType?|Content type, such as application/pdf, video/x-flv, image/jpeg
+[ByteSize](UI.xml#L316)|Int64?|Resource size in bytes
+[ChangedAt](UI.xml#L319)|DateTimeOffset?|Date of last change
+[Thumbnail](UI.xml#L322)|[ImageType?](#ImageType)|Thumbnail image
+[Title](UI.xml#L325)|[DataField?](#DataField)|Resource title
+[Description](UI.xml#L328)|[DataField?](#DataField)|Resource description
 
 <a name="ImageType"></a>
-## [ImageType](UI.xml#L315)
+## [ImageType](UI.xml#L332)
 Properties that describe an image
 
 Either `Url` or `Stream` MUST be present, and never both.
 
 Property|Type|Description
 :-------|:---|:----------
-[Url](UI.xml#L318)|URL|URL of image
-[Stream](UI.xml#L322) *([Experimental](Common.md#Experimental))*|Stream?|Stream of image<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[Width](UI.xml#L331)|String?|Width of image
-[Height](UI.xml#L334)|String?|Height of image
+[Url](UI.xml#L335)|URL|URL of image
+[Stream](UI.xml#L339) *([Experimental](Common.md#Experimental))*|Stream?|Stream of image<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[Width](UI.xml#L348)|String?|Width of image
+[Height](UI.xml#L351)|String?|Height of image
 
 <a name="DataPointType"></a>
-## [DataPointType](UI.xml#L355)
+## [DataPointType](UI.xml#L372)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L356)|String?|Title of the data point
-[Description](UI.xml#L360)|String?|Short description
-[LongDescription](UI.xml#L364)|String?|Full description
-[Value](UI.xml#L368)|PrimitiveType|Numeric value<br>The value is typically provided via a `Path` construct. The path MUST lead to a direct property of the same entity type or a property of a complex property (recursively) of that entity type, navigation segments are not allowed.<br/>It could be annotated with either `UoM.ISOCurrency` or `UoM.Unit`. Percentage values are annotated with `UoM.Unit = '%'`. A renderer should take an optional `Common.Text` annotation into consideration.
-[TargetValue](UI.xml#L380)|PrimitiveType?|Target value
-[ForecastValue](UI.xml#L383)|PrimitiveType?|Forecast value
-[MinimumValue](UI.xml#L386)|Decimal?|Minimum value (for output rendering)
-[MaximumValue](UI.xml#L389)|Decimal?|Maximum value (for output rendering)
-[ValueFormat](UI.xml#L392)|[NumberFormat?](#NumberFormat)|Number format
-[Visualization](UI.xml#L395)|[VisualizationType?](#VisualizationType)|Preferred visualization
-[SampleSize](UI.xml#L398)|PrimitiveType?|Sample size used for the determination of the data point; should contain just integer value as Edm.Byte, Edm.SByte, Edm.Intxx, and Edm.Decimal with scale 0.
-[ReferencePeriod](UI.xml#L405)|[ReferencePeriod?](#ReferencePeriod)|Reference period
-[Criticality](UI.xml#L408)|[CriticalityType?](#CriticalityType)|Service-calculated criticality, alternative to CriticalityCalculation
-[CriticalityLabels](UI.xml#L411)|AnnotationPath?|Custom labels for the criticality legend. Annotation path MUST end in UI.CriticalityLabels<br>Allowed terms:<ul><li>[CriticalityLabels](#CriticalityLabels)</li></ul>
-[CriticalityRepresentation](UI.xml#L419) *([Experimental](Common.md#Experimental))*|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[CriticalityCalculation](UI.xml#L423)|[CriticalityCalculationType?](#CriticalityCalculationType)|Parameters for client-calculated criticality, alternative to Criticality
-[Trend](UI.xml#L426)|[TrendType?](#TrendType)|Service-calculated trend, alternative to TrendCalculation
-[TrendCalculation](UI.xml#L429)|[TrendCalculationType?](#TrendCalculationType)|Parameters for client-calculated trend, alternative to Trend
-[Responsible](UI.xml#L432)|[ContactType?](Communication.md#ContactType)|Contact person
+[Title](UI.xml#L373)|String?|Title of the data point
+[Description](UI.xml#L377)|String?|Short description
+[LongDescription](UI.xml#L381)|String?|Full description
+[Value](UI.xml#L385)|PrimitiveType|Numeric value<br>The value is typically provided via a `Path` construct. The path MUST lead to a direct property of the same entity type or a property of a complex property (recursively) of that entity type, navigation segments are not allowed.<br/>It could be annotated with either `UoM.ISOCurrency` or `UoM.Unit`. Percentage values are annotated with `UoM.Unit = '%'`. A renderer should take an optional `Common.Text` annotation into consideration.
+[TargetValue](UI.xml#L397)|PrimitiveType?|Target value
+[ForecastValue](UI.xml#L400)|PrimitiveType?|Forecast value
+[MinimumValue](UI.xml#L403)|Decimal?|Minimum value (for output rendering)
+[MaximumValue](UI.xml#L406)|Decimal?|Maximum value (for output rendering)
+[ValueFormat](UI.xml#L409)|[NumberFormat?](#NumberFormat)|Number format
+[Visualization](UI.xml#L412)|[VisualizationType?](#VisualizationType)|Preferred visualization
+[SampleSize](UI.xml#L415)|PrimitiveType?|Sample size used for the determination of the data point; should contain just integer value as Edm.Byte, Edm.SByte, Edm.Intxx, and Edm.Decimal with scale 0.
+[ReferencePeriod](UI.xml#L422)|[ReferencePeriod?](#ReferencePeriod)|Reference period
+[Criticality](UI.xml#L425)|[CriticalityType?](#CriticalityType)|Service-calculated criticality, alternative to CriticalityCalculation
+[CriticalityLabels](UI.xml#L428)|AnnotationPath?|Custom labels for the criticality legend. Annotation path MUST end in UI.CriticalityLabels<br>Allowed terms:<ul><li>[CriticalityLabels](#CriticalityLabels)</li></ul>
+[CriticalityRepresentation](UI.xml#L436) *([Experimental](Common.md#Experimental))*|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[CriticalityCalculation](UI.xml#L440)|[CriticalityCalculationType?](#CriticalityCalculationType)|Parameters for client-calculated criticality, alternative to Criticality
+[Trend](UI.xml#L443)|[TrendType?](#TrendType)|Service-calculated trend, alternative to TrendCalculation
+[TrendCalculation](UI.xml#L446)|[TrendCalculationType?](#TrendCalculationType)|Parameters for client-calculated trend, alternative to Trend
+[Responsible](UI.xml#L449)|[ContactType?](Communication.md#ContactType)|Contact person
 
 <a name="NumberFormat"></a>
-## [NumberFormat](UI.xml#L437)
+## [NumberFormat](UI.xml#L454)
 Describes how to visualise a number
 
 Property|Type|Description
 :-------|:---|:----------
-[ScaleFactor](UI.xml#L439)|Decimal?|Display value in *ScaleFactor* units, e.g. 1000 for k (kilo), 1e6 for M (Mega)
-[NumberOfFractionalDigits](UI.xml#L442)|Byte?|Number of fractional digits of the scaled value to be visualized
+[ScaleFactor](UI.xml#L456)|Decimal?|Display value in *ScaleFactor* units, e.g. 1000 for k (kilo), 1e6 for M (Mega)
+[NumberOfFractionalDigits](UI.xml#L459)|Byte?|Number of fractional digits of the scaled value to be visualized
 
 <a name="VisualizationType"></a>
-## [VisualizationType](UI.xml#L447)
+## [VisualizationType](UI.xml#L464)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Number](UI.xml#L448)|0|Visualize as a number
-[BulletChart](UI.xml#L451)|1|Visualize as bullet chart - requires TargetValue
-[Progress](UI.xml#L454)|2|Visualize as progress indicator - requires TargetValue
-[Rating](UI.xml#L457)|3|Visualize as partially or completely filled stars/hearts/... - requires TargetValue
-[Donut](UI.xml#L460)|4|Visualize as donut, optionally with missing segment - requires TargetValue
-[DeltaBulletChart](UI.xml#L463)|5|Visualize as delta bullet chart - requires TargetValue
+[Number](UI.xml#L465)|0|Visualize as a number
+[BulletChart](UI.xml#L468)|1|Visualize as bullet chart - requires TargetValue
+[Progress](UI.xml#L471)|2|Visualize as progress indicator - requires TargetValue
+[Rating](UI.xml#L474)|3|Visualize as partially or completely filled stars/hearts/... - requires TargetValue
+[Donut](UI.xml#L477)|4|Visualize as donut, optionally with missing segment - requires TargetValue
+[DeltaBulletChart](UI.xml#L480)|5|Visualize as delta bullet chart - requires TargetValue
 
 <a name="ReferencePeriod"></a>
-## [ReferencePeriod](UI.xml#L468)
+## [ReferencePeriod](UI.xml#L485)
 Reference period
 
 Property|Type|Description
 :-------|:---|:----------
-[Description](UI.xml#L470)|String?|Short description of the reference period
-[Start](UI.xml#L474)|DateTimeOffset?|Start of the reference period
-[End](UI.xml#L477)|DateTimeOffset?|End of the reference period
+[Description](UI.xml#L487)|String?|Short description of the reference period
+[Start](UI.xml#L491)|DateTimeOffset?|Start of the reference period
+[End](UI.xml#L494)|DateTimeOffset?|End of the reference period
 
 <a name="CriticalityType"></a>
-## [CriticalityType](UI.xml#L482)
+## [CriticalityType](UI.xml#L499)
 Criticality of a value or status, represented e.g. via semantic colors (https://experience.sap.com/fiori-design-web/foundation/colors/#semantic-colors)
 
 Member|Value|Description
 :-----|----:|:----------
-[VeryNegative](UI.xml#L484) *([Experimental](Common.md#Experimental))*|-1|Very negative / dark-red status - risk - out of stock - late
-[Neutral](UI.xml#L488)|0|Neutral / grey status - inactive - open - in progress
-[Negative](UI.xml#L491)|1|Negative / red status - attention - overload - alert
-[Critical](UI.xml#L494)|2|Critical / orange status - warning
-[Positive](UI.xml#L497)|3|Positive / green status - completed - available - on track - acceptable
-[VeryPositive](UI.xml#L500) *([Experimental](Common.md#Experimental))*|4|Very positive - above max stock - excess
-[Information](UI.xml#L504) *([Experimental](Common.md#Experimental))*|5|Information - noticable - informative
+[VeryNegative](UI.xml#L501) *([Experimental](Common.md#Experimental))*|-1|Very negative / dark-red status - risk - out of stock - late
+[Neutral](UI.xml#L505)|0|Neutral / grey status - inactive - open - in progress
+[Negative](UI.xml#L508)|1|Negative / red status - attention - overload - alert
+[Critical](UI.xml#L511)|2|Critical / orange status - warning
+[Positive](UI.xml#L514)|3|Positive / green status - completed - available - on track - acceptable
+[VeryPositive](UI.xml#L517) *([Experimental](Common.md#Experimental))*|4|Very positive - above max stock - excess
+[Information](UI.xml#L521) *([Experimental](Common.md#Experimental))*|5|Information - noticable - informative
 
 <a name="CriticalityCalculationType"></a>
-## [CriticalityCalculationType](UI.xml#L510): [CriticalityThresholdsType](#CriticalityThresholdsType)
+## [CriticalityCalculationType](UI.xml#L527): [CriticalityThresholdsType](#CriticalityThresholdsType)
 Describes how to calculate the criticality of a value depending on the improvement direction
 
 
@@ -273,19 +275,19 @@ Thresholds are optional. For unassigned values, defaults are determined in this 
 
 Property|Type|Description
 :-------|:---|:----------
-[*AcceptanceRangeLowValue*](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
-[*AcceptanceRangeHighValue*](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
-[*ToleranceRangeLowValue*](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
-[*ToleranceRangeHighValue*](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
-[*DeviationRangeLowValue*](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
-[*DeviationRangeHighValue*](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
-[ReferenceValue](UI.xml#L545) *([Experimental](Common.md#Experimental))*|PrimitiveType?|Reference value for the calculation, e.g. number of sales for the last year
-[IsRelativeDifference](UI.xml#L549) *([Experimental](Common.md#Experimental))*|Boolean|Calculate with a relative difference
-[ImprovementDirection](UI.xml#L553)|[ImprovementDirectionType](#ImprovementDirectionType)|Describes in which direction the value improves
-[ConstantThresholds](UI.xml#L556) *([Experimental](Common.md#Experimental))*|\[[LevelThresholdsType](#LevelThresholdsType)\]|List of thresholds depending on the aggregation level as a set of constant values<br>Constant thresholds shall only be used in order to refine constant values given for the data point overall (aggregation level with empty collection of property paths), but not if the thresholds are based on other measure elements.
+[*AcceptanceRangeLowValue*](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
+[*AcceptanceRangeHighValue*](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
+[*ToleranceRangeLowValue*](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
+[*ToleranceRangeHighValue*](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
+[*DeviationRangeLowValue*](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
+[*DeviationRangeHighValue*](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
+[ReferenceValue](UI.xml#L562) *([Experimental](Common.md#Experimental))*|PrimitiveType?|Reference value for the calculation, e.g. number of sales for the last year
+[IsRelativeDifference](UI.xml#L566) *([Experimental](Common.md#Experimental))*|Boolean|Calculate with a relative difference
+[ImprovementDirection](UI.xml#L570)|[ImprovementDirectionType](#ImprovementDirectionType)|Describes in which direction the value improves
+[ConstantThresholds](UI.xml#L573) *([Experimental](Common.md#Experimental))*|\[[LevelThresholdsType](#LevelThresholdsType)\]|List of thresholds depending on the aggregation level as a set of constant values<br>Constant thresholds shall only be used in order to refine constant values given for the data point overall (aggregation level with empty collection of property paths), but not if the thresholds are based on other measure elements.
 
 <a name="CriticalityThresholdsType"></a>
-## [CriticalityThresholdsType](UI.xml#L563)
+## [CriticalityThresholdsType](UI.xml#L580)
 Thresholds for calculating the criticality of a value
 
 **Derived Types:**
@@ -294,51 +296,51 @@ Thresholds for calculating the criticality of a value
 
 Property|Type|Description
 :-------|:---|:----------
-[AcceptanceRangeLowValue](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
-[AcceptanceRangeHighValue](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
-[ToleranceRangeLowValue](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
-[ToleranceRangeHighValue](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
-[DeviationRangeLowValue](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
-[DeviationRangeHighValue](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
+[AcceptanceRangeLowValue](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
+[AcceptanceRangeHighValue](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
+[ToleranceRangeLowValue](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
+[ToleranceRangeHighValue](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
+[DeviationRangeLowValue](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
+[DeviationRangeHighValue](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
 
 <a name="ImprovementDirectionType"></a>
-## [ImprovementDirectionType](UI.xml#L585)
+## [ImprovementDirectionType](UI.xml#L602)
 Describes which direction of a value change is seen as an improvement
 
 Member|Value|Description
 :-----|----:|:----------
-[Minimize](UI.xml#L587)|1|Lower is better
-[Target](UI.xml#L590)|2|Closer to the target is better
-[Maximize](UI.xml#L593)|3|Higher is better
+[Minimize](UI.xml#L604)|1|Lower is better
+[Target](UI.xml#L607)|2|Closer to the target is better
+[Maximize](UI.xml#L610)|3|Higher is better
 
 <a name="LevelThresholdsType"></a>
-## [LevelThresholdsType](UI.xml#L598): [CriticalityThresholdsType](#CriticalityThresholdsType) *([Experimental](Common.md#Experimental))*
+## [LevelThresholdsType](UI.xml#L615): [CriticalityThresholdsType](#CriticalityThresholdsType) *([Experimental](Common.md#Experimental))*
 Thresholds for an aggregation level
 
 Property|Type|Description
 :-------|:---|:----------
-[*AcceptanceRangeLowValue*](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
-[*AcceptanceRangeHighValue*](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
-[*ToleranceRangeLowValue*](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
-[*ToleranceRangeHighValue*](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
-[*DeviationRangeLowValue*](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
-[*DeviationRangeHighValue*](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
-[AggregationLevel](UI.xml#L601)|\[PropertyPath\]|An unordered tuple of dimensions, i.e. properties which are intended to be used for grouping in aggregating requests. In analytical UIs, e.g. an analytical chart, the aggregation level typically corresponds to the visible dimensions.
+[*AcceptanceRangeLowValue*](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
+[*AcceptanceRangeHighValue*](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
+[*ToleranceRangeLowValue*](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
+[*ToleranceRangeHighValue*](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
+[*DeviationRangeLowValue*](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
+[*DeviationRangeHighValue*](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
+[AggregationLevel](UI.xml#L618)|\[PropertyPath\]|An unordered tuple of dimensions, i.e. properties which are intended to be used for grouping in aggregating requests. In analytical UIs, e.g. an analytical chart, the aggregation level typically corresponds to the visible dimensions.
 
 <a name="TrendType"></a>
-## [TrendType](UI.xml#L606)
+## [TrendType](UI.xml#L623)
 The trend of a value
 
 Member|Value|Description
 :-----|----:|:----------
-[StrongUp](UI.xml#L608)|1|Value grows strongly
-[Up](UI.xml#L611)|2|Value grows
-[Sideways](UI.xml#L614)|3|Value does not significantly grow or shrink
-[Down](UI.xml#L617)|4|Value shrinks
-[StrongDown](UI.xml#L620)|5|Value shrinks strongly
+[StrongUp](UI.xml#L625)|1|Value grows strongly
+[Up](UI.xml#L628)|2|Value grows
+[Sideways](UI.xml#L631)|3|Value does not significantly grow or shrink
+[Down](UI.xml#L634)|4|Value shrinks
+[StrongDown](UI.xml#L637)|5|Value shrinks strongly
 
 <a name="TrendCalculationType"></a>
-## [TrendCalculationType](UI.xml#L625)
+## [TrendCalculationType](UI.xml#L642)
 Describes how to calculate the trend of a value
 
 
@@ -354,220 +356,220 @@ The trend is
 
 Property|Type|Description
 :-------|:---|:----------
-[ReferenceValue](UI.xml#L639)|PrimitiveType|Reference value for the calculation, e.g. number of sales for the last year
-[IsRelativeDifference](UI.xml#L642)|Boolean|Calculate with a relative difference
-[UpDifference](UI.xml#L645)|Decimal|Threshold for Up
-[StrongUpDifference](UI.xml#L648)|Decimal|Threshold for StrongUp
-[DownDifference](UI.xml#L651)|Decimal|Threshold for Down
-[StrongDownDifference](UI.xml#L654)|Decimal|Threshold for StrongDown
+[ReferenceValue](UI.xml#L656)|PrimitiveType|Reference value for the calculation, e.g. number of sales for the last year
+[IsRelativeDifference](UI.xml#L659)|Boolean|Calculate with a relative difference
+[UpDifference](UI.xml#L662)|Decimal|Threshold for Up
+[StrongUpDifference](UI.xml#L665)|Decimal|Threshold for StrongUp
+[DownDifference](UI.xml#L668)|Decimal|Threshold for Down
+[StrongDownDifference](UI.xml#L671)|Decimal|Threshold for StrongDown
 
 <a name="KPIType"></a>
-## [KPIType](UI.xml#L665)
+## [KPIType](UI.xml#L682)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L666)|String?|Optional identifier to reference this instance from an external context
-[ShortDescription](UI.xml#L671) *([Experimental](Common.md#Experimental))*|String?|Very short description
-[SelectionVariant](UI.xml#L676)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
-[DataPoint](UI.xml#L679)|[DataPointType](#DataPointType)|Data point, either specified inline or referencing another annotation via Path
-[AdditionalDataPoints](UI.xml#L682)|\[[DataPointType](#DataPointType)\]|Additional data points, either specified inline or referencing another annotation via Path<br>Additional data points are typically related to the main data point and provide complementing information or could be used for comparisons
-[Detail](UI.xml#L686)|[KPIDetailType?](#KPIDetailType)|Contains information about KPI details, especially drill-down presentations
+[ID](UI.xml#L683)|String?|Optional identifier to reference this instance from an external context
+[ShortDescription](UI.xml#L688) *([Experimental](Common.md#Experimental))*|String?|Very short description
+[SelectionVariant](UI.xml#L693)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
+[DataPoint](UI.xml#L696)|[DataPointType](#DataPointType)|Data point, either specified inline or referencing another annotation via Path
+[AdditionalDataPoints](UI.xml#L699)|\[[DataPointType](#DataPointType)\]|Additional data points, either specified inline or referencing another annotation via Path<br>Additional data points are typically related to the main data point and provide complementing information or could be used for comparisons
+[Detail](UI.xml#L703)|[KPIDetailType?](#KPIDetailType)|Contains information about KPI details, especially drill-down presentations
 
 <a name="KPIDetailType"></a>
-## [KPIDetailType](UI.xml#L690)
+## [KPIDetailType](UI.xml#L707)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[DefaultPresentationVariant](UI.xml#L691)|[PresentationVariantType?](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
-[AlternativePresentationVariants](UI.xml#L694)|\[[PresentationVariantType](#PresentationVariantType)\]|A list of alternative presentation variants, either specified inline or referencing another annotation via Path
-[SemanticObject](UI.xml#L697)|String?|Name of the Semantic Object. If not specified, use Semantic Object annotated at the property referenced in KPI/DataPoint/Value
-[Action](UI.xml#L700)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[DefaultPresentationVariant](UI.xml#L708)|[PresentationVariantType?](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
+[AlternativePresentationVariants](UI.xml#L711)|\[[PresentationVariantType](#PresentationVariantType)\]|A list of alternative presentation variants, either specified inline or referencing another annotation via Path
+[SemanticObject](UI.xml#L714)|String?|Name of the Semantic Object. If not specified, use Semantic Object annotated at the property referenced in KPI/DataPoint/Value
+[Action](UI.xml#L717)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
 
 <a name="ChartDefinitionType"></a>
-## [ChartDefinitionType](UI.xml#L709)
+## [ChartDefinitionType](UI.xml#L726)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L710)|String?|Title of the chart
-[Description](UI.xml#L714)|String?|Short description
-[ChartType](UI.xml#L718)|[ChartType](#ChartType)|Chart type
-[AxisScaling](UI.xml#L721)|[ChartAxisScalingType?](#ChartAxisScalingType)|Describes the scale of the chart value axes
-[Measures](UI.xml#L724)|\[PropertyPath\]|Measures of the chart, e.g. size and color in a bubble chart
-[DynamicMeasures](UI.xml#L728)|\[AnnotationPath\]|Dynamic properties introduced by annotations and used as measures of the chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[MeasureAttributes](UI.xml#L741)|\[[ChartMeasureAttributeType](#ChartMeasureAttributeType)\]|Describes Attributes for Measures. All Measures used in this collection must also be part of the Measures Property.
-[Dimensions](UI.xml#L746)|\[PropertyPath\]|Dimensions of the chart, e.g. x- and y-axis of a bubble chart
-[DimensionAttributes](UI.xml#L749)|\[[ChartDimensionAttributeType](#ChartDimensionAttributeType)\]|Describes Attributes for Dimensions. All Dimensions used in this collection must also be part of the Dimensions Property.
-[Actions](UI.xml#L754)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Available actions
+[Title](UI.xml#L727)|String?|Title of the chart
+[Description](UI.xml#L731)|String?|Short description
+[ChartType](UI.xml#L735)|[ChartType](#ChartType)|Chart type
+[AxisScaling](UI.xml#L738)|[ChartAxisScalingType?](#ChartAxisScalingType)|Describes the scale of the chart value axes
+[Measures](UI.xml#L741)|\[PropertyPath\]|Measures of the chart, e.g. size and color in a bubble chart
+[DynamicMeasures](UI.xml#L745)|\[AnnotationPath\]|Dynamic properties introduced by annotations and used as measures of the chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[MeasureAttributes](UI.xml#L758)|\[[ChartMeasureAttributeType](#ChartMeasureAttributeType)\]|Describes Attributes for Measures. All Measures used in this collection must also be part of the Measures Property.
+[Dimensions](UI.xml#L763)|\[PropertyPath\]|Dimensions of the chart, e.g. x- and y-axis of a bubble chart
+[DimensionAttributes](UI.xml#L766)|\[[ChartDimensionAttributeType](#ChartDimensionAttributeType)\]|Describes Attributes for Dimensions. All Dimensions used in this collection must also be part of the Dimensions Property.
+[Actions](UI.xml#L771)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Available actions
 
 <a name="ChartType"></a>
-## [ChartType](UI.xml#L759)
+## [ChartType](UI.xml#L776)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Column](UI.xml#L760)|0|
-[ColumnStacked](UI.xml#L761)|1|
-[ColumnDual](UI.xml#L762)|2|
-[ColumnStackedDual](UI.xml#L763)|3|
-[ColumnStacked100](UI.xml#L764)|4|
-[ColumnStackedDual100](UI.xml#L765)|5|
-[Bar](UI.xml#L766)|6|
-[BarStacked](UI.xml#L767)|7|
-[BarDual](UI.xml#L768)|8|
-[BarStackedDual](UI.xml#L769)|9|
-[BarStacked100](UI.xml#L770)|10|
-[BarStackedDual100](UI.xml#L771)|11|
-[Area](UI.xml#L772)|12|
-[AreaStacked](UI.xml#L773)|13|
-[AreaStacked100](UI.xml#L774)|14|
-[HorizontalArea](UI.xml#L775)|15|
-[HorizontalAreaStacked](UI.xml#L776)|16|
-[HorizontalAreaStacked100](UI.xml#L777)|17|
-[Line](UI.xml#L778)|18|
-[LineDual](UI.xml#L779)|19|
-[Combination](UI.xml#L780)|20|
-[CombinationStacked](UI.xml#L781)|21|
-[CombinationDual](UI.xml#L782)|22|
-[CombinationStackedDual](UI.xml#L783)|23|
-[HorizontalCombinationStacked](UI.xml#L784)|24|
-[Pie](UI.xml#L785)|25|
-[Donut](UI.xml#L786)|26|
-[Scatter](UI.xml#L787)|27|
-[Bubble](UI.xml#L788)|28|
-[Radar](UI.xml#L789)|29|
-[HeatMap](UI.xml#L790)|30|
-[TreeMap](UI.xml#L791)|31|
-[Waterfall](UI.xml#L792)|32|
-[Bullet](UI.xml#L793)|33|
-[VerticalBullet](UI.xml#L794)|34|
-[HorizontalWaterfall](UI.xml#L795)|35|
-[HorizontalCombinationDual](UI.xml#L796)|36|
-[HorizontalCombinationStackedDual](UI.xml#L797)|37|
-[Donut100](UI.xml#L798) *([Experimental](Common.md#Experimental))*|38|
+[Column](UI.xml#L777)|0|
+[ColumnStacked](UI.xml#L778)|1|
+[ColumnDual](UI.xml#L779)|2|
+[ColumnStackedDual](UI.xml#L780)|3|
+[ColumnStacked100](UI.xml#L781)|4|
+[ColumnStackedDual100](UI.xml#L782)|5|
+[Bar](UI.xml#L783)|6|
+[BarStacked](UI.xml#L784)|7|
+[BarDual](UI.xml#L785)|8|
+[BarStackedDual](UI.xml#L786)|9|
+[BarStacked100](UI.xml#L787)|10|
+[BarStackedDual100](UI.xml#L788)|11|
+[Area](UI.xml#L789)|12|
+[AreaStacked](UI.xml#L790)|13|
+[AreaStacked100](UI.xml#L791)|14|
+[HorizontalArea](UI.xml#L792)|15|
+[HorizontalAreaStacked](UI.xml#L793)|16|
+[HorizontalAreaStacked100](UI.xml#L794)|17|
+[Line](UI.xml#L795)|18|
+[LineDual](UI.xml#L796)|19|
+[Combination](UI.xml#L797)|20|
+[CombinationStacked](UI.xml#L798)|21|
+[CombinationDual](UI.xml#L799)|22|
+[CombinationStackedDual](UI.xml#L800)|23|
+[HorizontalCombinationStacked](UI.xml#L801)|24|
+[Pie](UI.xml#L802)|25|
+[Donut](UI.xml#L803)|26|
+[Scatter](UI.xml#L804)|27|
+[Bubble](UI.xml#L805)|28|
+[Radar](UI.xml#L806)|29|
+[HeatMap](UI.xml#L807)|30|
+[TreeMap](UI.xml#L808)|31|
+[Waterfall](UI.xml#L809)|32|
+[Bullet](UI.xml#L810)|33|
+[VerticalBullet](UI.xml#L811)|34|
+[HorizontalWaterfall](UI.xml#L812)|35|
+[HorizontalCombinationDual](UI.xml#L813)|36|
+[HorizontalCombinationStackedDual](UI.xml#L814)|37|
+[Donut100](UI.xml#L815) *([Experimental](Common.md#Experimental))*|38|
 
 <a name="ChartAxisScalingType"></a>
-## [ChartAxisScalingType](UI.xml#L804)
+## [ChartAxisScalingType](UI.xml#L821)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ScaleBehavior](UI.xml#L805)|[ChartAxisScaleBehaviorType](#ChartAxisScaleBehaviorType)|Scale is fixed or adapts automatically to rendered values
-[AutoScaleBehavior](UI.xml#L808)|[ChartAxisAutoScaleBehaviorType?](#ChartAxisAutoScaleBehaviorType)|Settings for automatic scaling
-[FixedScaleMultipleStackedMeasuresBoundaryValues](UI.xml#L811)|[FixedScaleMultipleStackedMeasuresBoundaryValuesType?](#FixedScaleMultipleStackedMeasuresBoundaryValuesType)|Boundary values for fixed scaling of a stacking chart type with multiple measures
+[ScaleBehavior](UI.xml#L822)|[ChartAxisScaleBehaviorType](#ChartAxisScaleBehaviorType)|Scale is fixed or adapts automatically to rendered values
+[AutoScaleBehavior](UI.xml#L825)|[ChartAxisAutoScaleBehaviorType?](#ChartAxisAutoScaleBehaviorType)|Settings for automatic scaling
+[FixedScaleMultipleStackedMeasuresBoundaryValues](UI.xml#L828)|[FixedScaleMultipleStackedMeasuresBoundaryValuesType?](#FixedScaleMultipleStackedMeasuresBoundaryValuesType)|Boundary values for fixed scaling of a stacking chart type with multiple measures
 
 <a name="ChartAxisScaleBehaviorType"></a>
-## [ChartAxisScaleBehaviorType](UI.xml#L816)
+## [ChartAxisScaleBehaviorType](UI.xml#L833)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[AutoScale](UI.xml#L817)|0|Value axes scale automatically
-[FixedScale](UI.xml#L820)|1|Fixed minimum and maximum values are applied, which are derived from the @UI.MeasureAttributes.DataPoint/MinimumValue and .../MaximumValue annotation by default. For stacking chart types with multiple measures, they are taken from ChartAxisScalingType/FixedScaleMultipleStackedMeasuresBoundaryValues.
+[AutoScale](UI.xml#L834)|0|Value axes scale automatically
+[FixedScale](UI.xml#L837)|1|Fixed minimum and maximum values are applied, which are derived from the @UI.MeasureAttributes.DataPoint/MinimumValue and .../MaximumValue annotation by default. For stacking chart types with multiple measures, they are taken from ChartAxisScalingType/FixedScaleMultipleStackedMeasuresBoundaryValues.
 
 <a name="ChartAxisAutoScaleBehaviorType"></a>
-## [ChartAxisAutoScaleBehaviorType](UI.xml#L829)
+## [ChartAxisAutoScaleBehaviorType](UI.xml#L846)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ZeroAlwaysVisible](UI.xml#L830)|Boolean|Forces the value axis to always display the zero value
-[DataScope](UI.xml#L833)|[ChartAxisAutoScaleDataScopeType](#ChartAxisAutoScaleDataScopeType)|Determines the automatic scaling
+[ZeroAlwaysVisible](UI.xml#L847)|Boolean|Forces the value axis to always display the zero value
+[DataScope](UI.xml#L850)|[ChartAxisAutoScaleDataScopeType](#ChartAxisAutoScaleDataScopeType)|Determines the automatic scaling
 
 <a name="ChartAxisAutoScaleDataScopeType"></a>
-## [ChartAxisAutoScaleDataScopeType](UI.xml#L838)
+## [ChartAxisAutoScaleDataScopeType](UI.xml#L855)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[DataSet](UI.xml#L839)|0|Minimum and maximum axes values are determined from the entire data set
-[VisibleData](UI.xml#L842)|1|Minimum and maximum axes values are determined from the currently visible data. Scrolling will change the scale.
+[DataSet](UI.xml#L856)|0|Minimum and maximum axes values are determined from the entire data set
+[VisibleData](UI.xml#L859)|1|Minimum and maximum axes values are determined from the currently visible data. Scrolling will change the scale.
 
 <a name="FixedScaleMultipleStackedMeasuresBoundaryValuesType"></a>
-## [FixedScaleMultipleStackedMeasuresBoundaryValuesType](UI.xml#L847)
+## [FixedScaleMultipleStackedMeasuresBoundaryValuesType](UI.xml#L864)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[MinimumValue](UI.xml#L848)|Decimal|Minimum value on value axes
-[MaximumValue](UI.xml#L851)|Decimal|Maximum value on value axes
+[MinimumValue](UI.xml#L865)|Decimal|Minimum value on value axes
+[MaximumValue](UI.xml#L868)|Decimal|Maximum value on value axes
 
 <a name="ChartDimensionAttributeType"></a>
-## [ChartDimensionAttributeType](UI.xml#L856)
+## [ChartDimensionAttributeType](UI.xml#L873)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Dimension](UI.xml#L857)|PropertyPath?|
-[Role](UI.xml#L858)|[ChartDimensionRoleType?](#ChartDimensionRoleType)|
-[HierarchyLevel](UI.xml#L859) *([Experimental](Common.md#Experimental))*|Int32?|For a dimension with a hierarchy, members are selected from this level. The root node of the hierarchy is at level 0.
-[ValuesForSequentialColorLevels](UI.xml#L863) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be assigned to levels of the same color.
-[EmphasizedValues](UI.xml#L867) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be emphasized.
-[EmphasisLabels](UI.xml#L871) *([Experimental](Common.md#Experimental))*|[EmphasisLabelType?](#EmphasisLabelType)|Assign a label to values with an emphasized representation. This is required, if more than one emphasized value has been specified.
+[Dimension](UI.xml#L874)|PropertyPath?|
+[Role](UI.xml#L875)|[ChartDimensionRoleType?](#ChartDimensionRoleType)|
+[HierarchyLevel](UI.xml#L876) *([Experimental](Common.md#Experimental))*|Int32?|For a dimension with a hierarchy, members are selected from this level. The root node of the hierarchy is at level 0.
+[ValuesForSequentialColorLevels](UI.xml#L880) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be assigned to levels of the same color.
+[EmphasizedValues](UI.xml#L884) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be emphasized.
+[EmphasisLabels](UI.xml#L888) *([Experimental](Common.md#Experimental))*|[EmphasisLabelType?](#EmphasisLabelType)|Assign a label to values with an emphasized representation. This is required, if more than one emphasized value has been specified.
 
 <a name="ChartMeasureAttributeType"></a>
-## [ChartMeasureAttributeType](UI.xml#L877)
+## [ChartMeasureAttributeType](UI.xml#L894)
 Exactly one of `Measure` and `DynamicMeasure` must be present
 
 Property|Type|Description
 :-------|:---|:----------
-[Measure](UI.xml#L879)|PropertyPath?|
-[DynamicMeasure](UI.xml#L882)|AnnotationPath?|Dynamic property introduced by an annotation and used as a measure in a chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[Role](UI.xml#L895)|[ChartMeasureRoleType?](#ChartMeasureRoleType)|
-[DataPoint](UI.xml#L896)|AnnotationPath?|Annotation path MUST end in @UI.DataPoint and the data point's Value MUST be the same property as in Measure<br>Allowed terms:<ul><li>[DataPoint](#DataPoint)</li></ul>
-[UseSequentialColorLevels](UI.xml#L904) *([Experimental](Common.md#Experimental))*|Boolean|All measures for which this setting is true should be assigned to levels of the same color.
+[Measure](UI.xml#L896)|PropertyPath?|
+[DynamicMeasure](UI.xml#L899)|AnnotationPath?|Dynamic property introduced by an annotation and used as a measure in a chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[Role](UI.xml#L912)|[ChartMeasureRoleType?](#ChartMeasureRoleType)|
+[DataPoint](UI.xml#L913)|AnnotationPath?|Annotation path MUST end in @UI.DataPoint and the data point's Value MUST be the same property as in Measure<br>Allowed terms:<ul><li>[DataPoint](#DataPoint)</li></ul>
+[UseSequentialColorLevels](UI.xml#L921) *([Experimental](Common.md#Experimental))*|Boolean|All measures for which this setting is true should be assigned to levels of the same color.
 
 <a name="ChartDimensionRoleType"></a>
-## [ChartDimensionRoleType](UI.xml#L910)
+## [ChartDimensionRoleType](UI.xml#L927)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Category](UI.xml#L911)|0|
-[Series](UI.xml#L912)|1|
-[Category2](UI.xml#L913)|2|
+[Category](UI.xml#L928)|0|
+[Series](UI.xml#L929)|1|
+[Category2](UI.xml#L930)|2|
 
 <a name="ChartMeasureRoleType"></a>
-## [ChartMeasureRoleType](UI.xml#L916)
+## [ChartMeasureRoleType](UI.xml#L933)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Axis1](UI.xml#L917)|0|
-[Axis2](UI.xml#L918)|1|
-[Axis3](UI.xml#L919)|2|
+[Axis1](UI.xml#L934)|0|
+[Axis2](UI.xml#L935)|1|
+[Axis3](UI.xml#L936)|2|
 
 <a name="EmphasisLabelType"></a>
-## [EmphasisLabelType](UI.xml#L922) *([Experimental](Common.md#Experimental))*
+## [EmphasisLabelType](UI.xml#L939) *([Experimental](Common.md#Experimental))*
 Assigns a label to the set of emphasized values and optionally also for non-emphasized values. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[EmphasizedValuesLabel](UI.xml#L925)|String|
-[NonEmphasizedValuesLabel](UI.xml#L926)|String?|
+[EmphasizedValuesLabel](UI.xml#L942)|String|
+[NonEmphasizedValuesLabel](UI.xml#L943)|String?|
 
 <a name="ValueCriticalityType"></a>
-## [ValueCriticalityType](UI.xml#L933) *([Experimental](Common.md#Experimental))*
+## [ValueCriticalityType](UI.xml#L950) *([Experimental](Common.md#Experimental))*
 Assigns a fixed criticality to a primitive value. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[Value](UI.xml#L936)|PrimitiveType?|MUST be a fixed value of primitive type
-[Criticality](UI.xml#L939)|[CriticalityType?](#CriticalityType)|
+[Value](UI.xml#L953)|PrimitiveType?|MUST be a fixed value of primitive type
+[Criticality](UI.xml#L956)|[CriticalityType?](#CriticalityType)|
 
 <a name="CriticalityLabelType"></a>
-## [CriticalityLabelType](UI.xml#L953) *([Experimental](Common.md#Experimental))*
+## [CriticalityLabelType](UI.xml#L970) *([Experimental](Common.md#Experimental))*
 Assigns a label to a criticality. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[Criticality](UI.xml#L956)|[CriticalityType](#CriticalityType)|
-[Label](UI.xml#L957)|String|Criticality label
+[Criticality](UI.xml#L973)|[CriticalityType](#CriticalityType)|
+[Label](UI.xml#L974)|String|Criticality label
 
 <a name="Facet"></a>
-## [*Facet*](UI.xml#L991)
+## [*Facet*](UI.xml#L1007)
 Abstract base type for facets
 
 **Derived Types:**
@@ -577,8 +579,8 @@ Abstract base type for facets
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L999)|String?|Facet label
-[ID](UI.xml#L1003)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Label](UI.xml#L1015)|String?|Facet label
+[ID](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
 
 **Applicable Annotation Terms:**
 
@@ -586,14 +588,14 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="CollectionFacet"></a>
-## [CollectionFacet](UI.xml#L1007): [Facet](#Facet)
+## [CollectionFacet](UI.xml#L1023): [Facet](#Facet)
 Collection of facets
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L999)|String?|Facet label
-[*ID*](UI.xml#L1003)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Facets](UI.xml#L1009)|\[[Facet](#Facet)\]|Nested facets. An empty collection may be used as a placeholder for content added via extension points.
+[*Label*](UI.xml#L1015)|String?|Facet label
+[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Facets](UI.xml#L1025)|\[[Facet](#Facet)\]|Nested facets. An empty collection may be used as a placeholder for content added via extension points.
 
 **Applicable Annotation Terms:**
 
@@ -601,14 +603,14 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="ReferenceFacet"></a>
-## [ReferenceFacet](UI.xml#L1013): [Facet](#Facet)
+## [ReferenceFacet](UI.xml#L1029): [Facet](#Facet)
 Facet that refers to a thing perspective, e.g. LineItem
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L999)|String?|Facet label
-[*ID*](UI.xml#L1003)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Target](UI.xml#L1015)|AnnotationPath|Referenced information: Communication.Contact, Communication.Address, or a term that is tagged with UI.ThingPerspective, e.g. UI.StatusInfo, UI.LineItem, UI.Identification, UI.FieldGroup, UI.Badge<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Badge](#Badge)</li><li>[Chart](#Chart)</li><li>[Contacts](#Contacts)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li><li>[GeoLocation](#GeoLocation)</li><li>[GeoLocations](#GeoLocations)</li><li>[HeaderInfo](#HeaderInfo)</li><li>[Identification](#Identification)</li><li>[KPI](#KPI)</li><li>[LineItem](#LineItem)</li><li>[MediaResource](#MediaResource)</li><li>[Note](#Note)</li><li>[PresentationVariant](#PresentationVariant)</li><li>[SelectionFields](#SelectionFields)</li><li>[SelectionPresentationVariant](#SelectionPresentationVariant)</li><li>[StatusInfo](#StatusInfo)</li></ul>
+[*Label*](UI.xml#L1015)|String?|Facet label
+[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Target](UI.xml#L1031)|AnnotationPath|Referenced information: Communication.Contact, Communication.Address, or a term that is tagged with UI.ThingPerspective, e.g. UI.StatusInfo, UI.LineItem, UI.Identification, UI.FieldGroup, UI.Badge<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Badge](#Badge)</li><li>[Chart](#Chart)</li><li>[Contacts](#Contacts)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li><li>[GeoLocation](#GeoLocation)</li><li>[GeoLocations](#GeoLocations)</li><li>[HeaderInfo](#HeaderInfo)</li><li>[Identification](#Identification)</li><li>[KPI](#KPI)</li><li>[LineItem](#LineItem)</li><li>[MediaResource](#MediaResource)</li><li>[Note](#Note)</li><li>[PresentationVariant](#PresentationVariant)</li><li>[SelectionFields](#SelectionFields)</li><li>[SelectionPresentationVariant](#SelectionPresentationVariant)</li><li>[StatusInfo](#StatusInfo)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -616,15 +618,15 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="ReferenceURLFacet"></a>
-## [ReferenceURLFacet](UI.xml#L1042): [Facet](#Facet)
+## [ReferenceURLFacet](UI.xml#L1058): [Facet](#Facet)
 Facet that refers to a URL
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L999)|String?|Facet label
-[*ID*](UI.xml#L1003)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Url](UI.xml#L1044)|URL|URL of referenced information<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](UI.xml#L1053)|MediaType?|Media type of referenced information
+[*Label*](UI.xml#L1015)|String?|Facet label
+[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Url](UI.xml#L1060)|URL|URL of referenced information<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](UI.xml#L1069)|MediaType?|Media type of referenced information
 
 **Applicable Annotation Terms:**
 
@@ -632,50 +634,51 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="SelectionPresentationVariantType"></a>
-## [SelectionPresentationVariantType](UI.xml#L1066)
+## [SelectionPresentationVariantType](UI.xml#L1082)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1067)|String?|Optional identifier to reference this variant from an external context
-[Text](UI.xml#L1072)|String?|Name of the bundling variant
-[SelectionVariant](UI.xml#L1076)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
-[PresentationVariant](UI.xml#L1079)|[PresentationVariantType](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
+[ID](UI.xml#L1083)|String?|Optional identifier to reference this variant from an external context
+[Text](UI.xml#L1088)|String?|Name of the bundling variant
+[SelectionVariant](UI.xml#L1092)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
+[PresentationVariant](UI.xml#L1095)|[PresentationVariantType](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
 
 <a name="PresentationVariantType"></a>
-## [PresentationVariantType](UI.xml#L1090)
+## [PresentationVariantType](UI.xml#L1106)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1091)|String?|Optional identifier to reference this variant from an external context
-[Text](UI.xml#L1094)|String?|Name of the presentation variant
-[MaxItems](UI.xml#L1098)|Int32?|Maximum number of items that should be included in the result
-[SortOrder](UI.xml#L1101)|\[[SortOrderType](Common.md#SortOrderType)\]|Collection can be provided inline or as a reference to a Common.SortOrder annotation via Path
-[GroupBy](UI.xml#L1104)|\[PropertyPath\]|Sequence of groupable properties p1, p2, ... defining how the result is composed of instances representing groups, one for each combination of value properties in the queried collection. The sequence specifies a certain level of aggregation for the queried collection, and every group instance will provide aggregated values for properties that are aggregatable. Moreover, the series of sub-sequences (p1), (p1, p2), ... forms a leveled hierarchy, which may become relevant in combination with `InitialExpansionLevel`.
-[TotalBy](UI.xml#L1113)|\[PropertyPath\]|Sub-sequence q1, q2, ... of properties p1, p2, ... specified in GroupBy. With this, additional levels of aggregation are requested in addition to the most granular level defined by GroupBy: Every element in the series of sub-sequences (q1), (q1, q2), ... introduces an additional aggregation level included in the result.
-[Total](UI.xml#L1120)|\[PropertyPath\]|Aggregatable properties for which aggregated values should be provided for the additional aggregation levels specified in TotalBy.
-[DynamicTotal](UI.xml#L1126)|\[AnnotationPath\]|Dynamic properties introduced by annotations for which aggregated values should be provided for the additional aggregation levels specified in TotalBy<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being presented according to the `UI.PresentationVariant` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[IncludeGrandTotal](UI.xml#L1139)|Boolean|Result should include a grand total for the properties specified in Total
-[InitialExpansionLevel](UI.xml#L1142)|Int32|Level up to which the hierarchy defined for the queried collection should be expanded initially. The hierarchy may be implicitly imposed by the sequence of the GroupBy, or by an explicit hierarchy annotation.
-[Visualizations](UI.xml#L1148)|\[AnnotationPath\]|Lists available visualization types. Currently supported types are `UI.LineItem`, `UI.Chart`, and `UI.DataPoint`. For each type, no more than a single annotation is meaningful. Multiple instances of the same visualization type shall be modeled with different presentation variants. A reference to `UI.Lineitem` should always be part of the collection (least common denominator for renderers). The first entry of the collection is the default visualization.<br>Allowed terms:<ul><li>[Chart](#Chart)</li><li>[DataPoint](#DataPoint)</li><li>[LineItem](#LineItem)</li></ul>
-[RequestAtLeast](UI.xml#L1165)|\[PropertyPath\]|Properties that should always be included in the result of the queried collection<br>Properties in `RequestAtLeast` must occur either in the `$select` clause of an OData request or among the grouping properties in an `$apply=groupby((grouping properties),...)` clause of an aggregating OData request.
-[SelectionFields](UI.xml#L1188) *([Experimental](Common.md#Experimental))*|\[PropertyPath\]|Properties that should be presented for filtering a collection of entities. Can be provided inline or as a reference to a `UI.SelectionFields` annotation via Path.
+[ID](UI.xml#L1107)|String?|Optional identifier to reference this variant from an external context
+[Text](UI.xml#L1110)|String?|Name of the presentation variant
+[MaxItems](UI.xml#L1114)|Int32?|Maximum number of items that should be included in the result
+[SortOrder](UI.xml#L1117)|\[[SortOrderType](Common.md#SortOrderType)\]|Collection can be provided inline or as a reference to a Common.SortOrder annotation via Path
+[GroupBy](UI.xml#L1120)|\[PropertyPath\]|Sequence of groupable properties p1, p2, ... defining how the result is composed of instances representing groups, one for each combination of value properties in the queried collection. The sequence specifies a certain level of aggregation for the queried collection, and every group instance will provide aggregated values for properties that are aggregatable. Moreover, the series of sub-sequences (p1), (p1, p2), ... forms a leveled hierarchy, which may become relevant in combination with `InitialExpansionLevel`.
+[TotalBy](UI.xml#L1129)|\[PropertyPath\]|Sub-sequence q1, q2, ... of properties p1, p2, ... specified in GroupBy. With this, additional levels of aggregation are requested in addition to the most granular level defined by GroupBy: Every element in the series of sub-sequences (q1), (q1, q2), ... introduces an additional aggregation level included in the result.
+[Total](UI.xml#L1136)|\[PropertyPath\]|Aggregatable properties for which aggregated values should be provided for the additional aggregation levels specified in TotalBy.
+[DynamicTotal](UI.xml#L1142)|\[AnnotationPath\]|Dynamic properties introduced by annotations for which aggregated values should be provided for the additional aggregation levels specified in TotalBy<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being presented according to the `UI.PresentationVariant` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[IncludeGrandTotal](UI.xml#L1155)|Boolean|Result should include a grand total for the properties specified in Total
+[InitialExpansionLevel](UI.xml#L1158)|Int32|Level up to which the hierarchy defined for the queried collection should be expanded initially. The hierarchy may be implicitly imposed by the sequence of the GroupBy, or by an explicit hierarchy annotation.
+[Visualizations](UI.xml#L1164)|\[AnnotationPath\]|Lists available visualization types. Currently supported types are `UI.LineItem`, `UI.Chart`, and `UI.DataPoint`. For each type, no more than a single annotation is meaningful. Multiple instances of the same visualization type shall be modeled with different presentation variants. A reference to `UI.Lineitem` should always be part of the collection (least common denominator for renderers). The first entry of the collection is the default visualization.<br>Allowed terms:<ul><li>[Chart](#Chart)</li><li>[DataPoint](#DataPoint)</li><li>[LineItem](#LineItem)</li></ul>
+[RecursiveHierarchyQualifier](UI.xml#L1181) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|Qualifier of the recursive hierarchy that should be applied to the Visualization<br>Variant 1 for hierarchical LineItems
+[RequestAtLeast](UI.xml#L1188)|\[PropertyPath\]|Properties that should always be included in the result of the queried collection<br>Properties in `RequestAtLeast` must occur either in the `$select` clause of an OData request or among the grouping properties in an `$apply=groupby((grouping properties),...)` clause of an aggregating OData request.
+[SelectionFields](UI.xml#L1211) *([Experimental](Common.md#Experimental))*|\[PropertyPath\]|Properties that should be presented for filtering a collection of entities. Can be provided inline or as a reference to a `UI.SelectionFields` annotation via Path.
 
 <a name="SelectionVariantType"></a>
-## [SelectionVariantType](UI.xml#L1202)
+## [SelectionVariantType](UI.xml#L1225)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1203)|String?|May contain identifier to reference this instance from an external context
-[Text](UI.xml#L1208)|String?|Name of the selection variant
-[Parameters](UI.xml#L1212)|\[[ParameterAbstract](#ParameterAbstract)\]|Parameters of the selection variant
-[FilterExpression](UI.xml#L1215)|String?|Filter string for query part of URL, without `$filter=`
-[SelectOptions](UI.xml#L1220)|\[[SelectOptionType](#SelectOptionType)\]|ABAP Select Options Pattern
+[ID](UI.xml#L1226)|String?|May contain identifier to reference this instance from an external context
+[Text](UI.xml#L1231)|String?|Name of the selection variant
+[Parameters](UI.xml#L1235)|\[[ParameterAbstract](#ParameterAbstract)\]|Parameters of the selection variant
+[FilterExpression](UI.xml#L1238)|String?|Filter string for query part of URL, without `$filter=`
+[SelectOptions](UI.xml#L1243)|\[[SelectOptionType](#SelectOptionType)\]|ABAP Select Options Pattern
 
 <a name="ParameterAbstract"></a>
-## [*ParameterAbstract*](UI.xml#L1227)
+## [*ParameterAbstract*](UI.xml#L1250)
 Key property of a parameter entity type
 
 **Derived Types:**
@@ -683,128 +686,128 @@ Key property of a parameter entity type
 - [IntervalParameter](#IntervalParameter)
 
 <a name="Parameter"></a>
-## [Parameter](UI.xml#L1230): [ParameterAbstract](#ParameterAbstract)
+## [Parameter](UI.xml#L1253): [ParameterAbstract](#ParameterAbstract)
 Single-valued parameter
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyName](UI.xml#L1232)|PropertyPath|Path to a key property of a parameter entity type
-[PropertyValue](UI.xml#L1235)|PrimitiveType|Value for the key property
+[PropertyName](UI.xml#L1255)|PropertyPath|Path to a key property of a parameter entity type
+[PropertyValue](UI.xml#L1258)|PrimitiveType|Value for the key property
 
 <a name="IntervalParameter"></a>
-## [IntervalParameter](UI.xml#L1239): [ParameterAbstract](#ParameterAbstract)
+## [IntervalParameter](UI.xml#L1262): [ParameterAbstract](#ParameterAbstract)
 Interval parameter formed with a 'from' and a 'to' property
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyNameFrom](UI.xml#L1241)|PropertyPath|Path to the 'from' property of a parameter entity type
-[PropertyValueFrom](UI.xml#L1244)|PrimitiveType|Value for the 'from' property
-[PropertyNameTo](UI.xml#L1247)|PropertyPath|Path to the 'to' property of a parameter entity type
-[PropertyValueTo](UI.xml#L1250)|PrimitiveType|Value for the 'to' property
+[PropertyNameFrom](UI.xml#L1264)|PropertyPath|Path to the 'from' property of a parameter entity type
+[PropertyValueFrom](UI.xml#L1267)|PrimitiveType|Value for the 'from' property
+[PropertyNameTo](UI.xml#L1270)|PropertyPath|Path to the 'to' property of a parameter entity type
+[PropertyValueTo](UI.xml#L1273)|PrimitiveType|Value for the 'to' property
 
 <a name="SelectOptionType"></a>
-## [SelectOptionType](UI.xml#L1255)
+## [SelectOptionType](UI.xml#L1278)
 List of value ranges for a single property
 
 Exactly one of `PropertyName` and `DynamicPropertyName` must be present
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyName](UI.xml#L1258)|PropertyPath?|Path to the property
-[DynamicPropertyName](UI.xml#L1270)|AnnotationPath?|Dynamic property introduced by annotations for which value ranges are specified<br>If the annotation referenced by the annotation path does not apply to the same collection of entities as the one being filtered according to the `UI.SelectionVariant` annotation, this instance of `UI.SelectionVariant/SelectOptions` MUST be silently ignored. For an example, see the `UI.SelectionVariant` annotation in the [example](../examples/DynamicProperties-sample.xml).<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[Ranges](UI.xml#L1284)|\[[SelectionRangeType](#SelectionRangeType)\]|List of value ranges
+[PropertyName](UI.xml#L1281)|PropertyPath?|Path to the property
+[DynamicPropertyName](UI.xml#L1293)|AnnotationPath?|Dynamic property introduced by annotations for which value ranges are specified<br>If the annotation referenced by the annotation path does not apply to the same collection of entities as the one being filtered according to the `UI.SelectionVariant` annotation, this instance of `UI.SelectionVariant/SelectOptions` MUST be silently ignored. For an example, see the `UI.SelectionVariant` annotation in the [example](../examples/DynamicProperties-sample.xml).<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[Ranges](UI.xml#L1307)|\[[SelectionRangeType](#SelectionRangeType)\]|List of value ranges
 
 <a name="SelectionRangeType"></a>
-## [SelectionRangeType](UI.xml#L1289)
+## [SelectionRangeType](UI.xml#L1312)
 Value range. If the range option only requires a single value, the value must be in the property Low
 
 Property|Type|Description
 :-------|:---|:----------
-[Sign](UI.xml#L1293)|[SelectionRangeSignType](#SelectionRangeSignType)|Include or exclude values
-[Option](UI.xml#L1296)|[SelectionRangeOptionType](#SelectionRangeOptionType)|Comparison operator
-[Low](UI.xml#L1299)|PrimitiveType|Single value or lower interval boundary
-[High](UI.xml#L1302)|PrimitiveType?|Upper interval boundary
+[Sign](UI.xml#L1316)|[SelectionRangeSignType](#SelectionRangeSignType)|Include or exclude values
+[Option](UI.xml#L1319)|[SelectionRangeOptionType](#SelectionRangeOptionType)|Comparison operator
+[Low](UI.xml#L1322)|PrimitiveType|Single value or lower interval boundary
+[High](UI.xml#L1325)|PrimitiveType?|Upper interval boundary
 
 <a name="SelectionRangeSignType"></a>
-## [SelectionRangeSignType](UI.xml#L1307)
+## [SelectionRangeSignType](UI.xml#L1330)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[I](UI.xml#L1308)|0|Inclusive
-[E](UI.xml#L1311)|1|Exclusive
+[I](UI.xml#L1331)|0|Inclusive
+[E](UI.xml#L1334)|1|Exclusive
 
 <a name="SelectionRangeOptionType"></a>
-## [SelectionRangeOptionType](UI.xml#L1316)
+## [SelectionRangeOptionType](UI.xml#L1339)
 Comparison operator
 
 Member|Value|Description
 :-----|----:|:----------
-[EQ](UI.xml#L1318)|0|Equal to
-[BT](UI.xml#L1321)|1|Between
-[CP](UI.xml#L1324)|2|Contains pattern
-[LE](UI.xml#L1327)|3|Less than or equal to
-[GE](UI.xml#L1330)|4|Greater than or equal to
-[NE](UI.xml#L1333)|5|Not equal to
-[NB](UI.xml#L1336)|6|Not between
-[NP](UI.xml#L1339)|7|Does not contain pattern
-[GT](UI.xml#L1342)|8|Greater than
-[LT](UI.xml#L1345)|9|Less than
+[EQ](UI.xml#L1341)|0|Equal to
+[BT](UI.xml#L1344)|1|Between
+[CP](UI.xml#L1347)|2|Contains pattern
+[LE](UI.xml#L1350)|3|Less than or equal to
+[GE](UI.xml#L1353)|4|Greater than or equal to
+[NE](UI.xml#L1356)|5|Not equal to
+[NB](UI.xml#L1359)|6|Not between
+[NP](UI.xml#L1362)|7|Does not contain pattern
+[GT](UI.xml#L1365)|8|Greater than
+[LT](UI.xml#L1368)|9|Less than
 
 <a name="InputMaskType"></a>
-## [InputMaskType](UI.xml#L1413) *([Experimental](Common.md#Experimental))*
+## [InputMaskType](UI.xml#L1436) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Mask](UI.xml#L1415)|String|The mask to be applied to the property or the parameter
-[PlaceholderSymbol](UI.xml#L1418)|String|A single character symbol to be shown where the user can type a character
-[Rules](UI.xml#L1421)|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[Mask](UI.xml#L1438)|String|The mask to be applied to the property or the parameter
+[PlaceholderSymbol](UI.xml#L1441)|String|A single character symbol to be shown where the user can type a character
+[Rules](UI.xml#L1444)|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
-## [InputMaskRuleType](UI.xml#L1428) *([Experimental](Common.md#Experimental))*
+## [InputMaskRuleType](UI.xml#L1451) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[MaskSymbol](UI.xml#L1430)|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
-[RegExp](UI.xml#L1433)|String|Regular expression that defines the valid values for the mask symbol
+[MaskSymbol](UI.xml#L1453)|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
+[RegExp](UI.xml#L1456)|String|Regular expression that defines the valid values for the mask symbol
 
 <a name="TextArrangementType"></a>
-## [TextArrangementType](UI.xml#L1446)
+## [TextArrangementType](UI.xml#L1469)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[TextFirst](UI.xml#L1447)|0|Text is first, followed by the code/ID (e.g. in parentheses)
-[TextLast](UI.xml#L1450)|1|Code/ID is first, followed by the text (e.g. separated by a dash)
-[TextSeparate](UI.xml#L1453)|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
-[TextOnly](UI.xml#L1456)|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
+[TextFirst](UI.xml#L1470)|0|Text is first, followed by the code/ID (e.g. in parentheses)
+[TextLast](UI.xml#L1473)|1|Code/ID is first, followed by the text (e.g. separated by a dash)
+[TextSeparate](UI.xml#L1476)|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
+[TextOnly](UI.xml#L1479)|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
 
 <a name="NoteType"></a>
-## [NoteType](UI.xml#L1473) *([Experimental](Common.md#Experimental))*
+## [NoteType](UI.xml#L1496) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L1475)|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
-[Content](UI.xml#L1487)|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
-[Type](UI.xml#L1503)|String|A type used for grouping notes
-[MaximalLength](UI.xml#L1506)|Int32?|Type-specific maximal length of the content of the note
-[MultipleNotes](UI.xml#L1509)|Boolean|Whether the type allows multiple notes for one object
+[Title](UI.xml#L1498)|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
+[Content](UI.xml#L1510)|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
+[Type](UI.xml#L1526)|String|A type used for grouping notes
+[MaximalLength](UI.xml#L1529)|Int32?|Type-specific maximal length of the content of the note
+[MultipleNotes](UI.xml#L1532)|Boolean|Whether the type allows multiple notes for one object
 
 <a name="ImportanceType"></a>
-## [ImportanceType](UI.xml#L1517)
+## [ImportanceType](UI.xml#L1540)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[High](UI.xml#L1518)|0|High importance
-[Medium](UI.xml#L1521)|1|Medium importance
-[Low](UI.xml#L1524)|2|Low importance
+[High](UI.xml#L1541)|0|High importance
+[Medium](UI.xml#L1544)|1|Medium importance
+[Low](UI.xml#L1547)|2|Low importance
 
 <a name="DataFieldAbstract"></a>
-## [*DataFieldAbstract*](UI.xml#L1584)
+## [*DataFieldAbstract*](UI.xml#L1607)
 Elementary building block that represents a piece of data and/or allows triggering an action
 
 By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the visibility, the importance and
@@ -825,10 +828,10 @@ By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[Criticality](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[CriticalityRepresentation](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[IconUrl](UI.xml#L1610)|URL?|Optional icon
+[Label](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[Criticality](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[CriticalityRepresentation](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[IconUrl](UI.xml#L1633)|URL?|Optional icon
 
 **Applicable Annotation Terms:**
 
@@ -840,26 +843,26 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="CriticalityRepresentationType"></a>
-## [CriticalityRepresentationType](UI.xml#L1616)
+## [CriticalityRepresentationType](UI.xml#L1639)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[WithIcon](UI.xml#L1617)|0|Criticality is represented with an icon
-[WithoutIcon](UI.xml#L1620)|1|Criticality is represented without icon, e.g. only via text color
-[OnlyIcon](UI.xml#L1623) *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
+[WithIcon](UI.xml#L1640)|0|Criticality is represented with an icon
+[WithoutIcon](UI.xml#L1643)|1|Criticality is represented without icon, e.g. only via text color
+[OnlyIcon](UI.xml#L1646) *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
 
 <a name="DataFieldForAnnotation"></a>
-## [DataFieldForAnnotation](UI.xml#L1629): [DataFieldAbstract](#DataFieldAbstract)
+## [DataFieldForAnnotation](UI.xml#L1652): [DataFieldAbstract](#DataFieldAbstract)
 A structured piece of data described by an annotation
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Target](UI.xml#L1631)|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Target](UI.xml#L1654)|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -871,7 +874,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionAbstract"></a>
-## [*DataFieldForActionAbstract*](UI.xml#L1646): [DataFieldAbstract](#DataFieldAbstract)
+## [*DataFieldForActionAbstract*](UI.xml#L1669): [DataFieldAbstract](#DataFieldAbstract)
 Triggers an action
 
 **Derived Types:**
@@ -880,12 +883,12 @@ Triggers an action
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Inline](UI.xml#L1648)|Boolean|Action should be placed close to (or even inside) the visualized term
-[Determining](UI.xml#L1651)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Inline](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
+[Determining](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
 
 **Applicable Annotation Terms:**
 
@@ -897,21 +900,21 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForAction"></a>
-## [DataFieldForAction](UI.xml#L1656): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForAction](UI.xml#L1679): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers an OData action
 
 The action is NOT tied to a data value (in contrast to [DataFieldWithAction](#DataFieldWithAction)).
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[*Inline*](UI.xml#L1648)|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](UI.xml#L1651)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[Action](UI.xml#L1659)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
-[InvocationGrouping](UI.xml#L1662)|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[*Inline*](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[Action](UI.xml#L1682)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[InvocationGrouping](UI.xml#L1685)|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
 
 **Applicable Annotation Terms:**
 
@@ -923,16 +926,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="OperationGroupingType"></a>
-## [OperationGroupingType](UI.xml#L1666)
+## [OperationGroupingType](UI.xml#L1689)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Isolated](UI.xml#L1667)|0|Invoke each action in isolation from other actions
-[ChangeSet](UI.xml#L1670)|1|Group all actions into a single change set
+[Isolated](UI.xml#L1690)|0|Invoke each action in isolation from other actions
+[ChangeSet](UI.xml#L1693)|1|Group all actions into a single change set
 
 <a name="DataFieldForIntentBasedNavigation"></a>
-## [DataFieldForIntentBasedNavigation](UI.xml#L1675): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForIntentBasedNavigation](UI.xml#L1698): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -941,17 +944,17 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[*Inline*](UI.xml#L1648)|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](UI.xml#L1651)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[SemanticObject](UI.xml#L1682)|String|Name of the Semantic Object
-[Action](UI.xml#L1685)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[NavigationAvailable](UI.xml#L1688)|Boolean|The navigation intent is for that user with the selected context and parameters available
-[RequiresContext](UI.xml#L1691)|Boolean|Determines whether a context needs to be passed to the target of this navigation.
-[Mapping](UI.xml#L1694)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[*Inline*](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[SemanticObject](UI.xml#L1705)|String|Name of the Semantic Object
+[Action](UI.xml#L1708)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[NavigationAvailable](UI.xml#L1711)|Boolean|The navigation intent is for that user with the selected context and parameters available
+[RequiresContext](UI.xml#L1714)|Boolean|Determines whether a context needs to be passed to the target of this navigation.
+[Mapping](UI.xml#L1717)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -963,16 +966,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionGroup"></a>
-## [DataFieldForActionGroup](UI.xml#L1699): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
+## [DataFieldForActionGroup](UI.xml#L1722): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Actions](UI.xml#L1702)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Actions](UI.xml#L1725)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
 
 **Applicable Annotation Terms:**
 
@@ -984,7 +987,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataField"></a>
-## [DataField](UI.xml#L1707): [DataFieldAbstract](#DataFieldAbstract)
+## [DataField](UI.xml#L1730): [DataFieldAbstract](#DataFieldAbstract)
 A piece of data
 
 **Derived Types:**
@@ -996,11 +999,11 @@ A piece of data
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1709)|Untyped|The data field's value
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1732)|Untyped|The data field's value
 
 **Applicable Annotation Terms:**
 
@@ -1012,19 +1015,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithAction"></a>
-## [DataFieldWithAction](UI.xml#L1736): [DataField](#DataField)
+## [DataFieldWithAction](UI.xml#L1759): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
 The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1739)|PrimitiveType|The data field's value
-[Action](UI.xml#L1740)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1762)|PrimitiveType|The data field's value
+[Action](UI.xml#L1763)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
 
 **Applicable Annotation Terms:**
 
@@ -1036,7 +1039,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithIntentBasedNavigation"></a>
-## [DataFieldWithIntentBasedNavigation](UI.xml#L1745): [DataField](#DataField)
+## [DataFieldWithIntentBasedNavigation](UI.xml#L1768): [DataField](#DataField)
 A piece of data that allows triggering intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -1046,14 +1049,14 @@ This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBa
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1753)|PrimitiveType|The data field's value
-[SemanticObject](UI.xml#L1754)|String|Name of the Semantic Object
-[Action](UI.xml#L1757)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[Mapping](UI.xml#L1760)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1776)|PrimitiveType|The data field's value
+[SemanticObject](UI.xml#L1777)|String|Name of the Semantic Object
+[Action](UI.xml#L1780)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[Mapping](UI.xml#L1783)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -1065,19 +1068,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithNavigationPath"></a>
-## [DataFieldWithNavigationPath](UI.xml#L1765): [DataField](#DataField)
+## [DataFieldWithNavigationPath](UI.xml#L1788): [DataField](#DataField)
 A piece of data that allows navigating to related data
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1768)|PrimitiveType|The data field's value
-[Target](UI.xml#L1769)|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1791)|PrimitiveType|The data field's value
+[Target](UI.xml#L1792)|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
 
 **Applicable Annotation Terms:**
 
@@ -1089,20 +1092,20 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithUrl"></a>
-## [DataFieldWithUrl](UI.xml#L1776): [DataField](#DataField)
+## [DataFieldWithUrl](UI.xml#L1799): [DataField](#DataField)
 A piece of data that allows navigating to other information on the Web
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1779)|PrimitiveType|The data field's value
-[Url](UI.xml#L1780)|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](UI.xml#L1789)|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1802)|PrimitiveType|The data field's value
+[Url](UI.xml#L1803)|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](UI.xml#L1812)|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
 
 **Applicable Annotation Terms:**
 
@@ -1114,17 +1117,17 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithActionGroup"></a>
-## [DataFieldWithActionGroup](UI.xml#L1795): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
+## [DataFieldWithActionGroup](UI.xml#L1818): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1600)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1604)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1607)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1610)|URL?|Optional icon
-[Value](UI.xml#L1798)|PrimitiveType|The data field's value
-[Actions](UI.xml#L1799)|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
+[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
+[Value](UI.xml#L1821)|PrimitiveType|The data field's value
+[Actions](UI.xml#L1822)|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
 
 **Applicable Annotation Terms:**
 
@@ -1136,7 +1139,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="RecommendationStateType"></a>
-## [RecommendationStateType](UI.xml#L1837)
+## [RecommendationStateType](UI.xml#L1860)
 **Type:** Byte
 
 Indicates whether a field contains or has a recommended value
@@ -1145,33 +1148,33 @@ Editable fields for which a recommendation has been pre-filled or that have reco
 
 Allowed Value|Description
 :------------|:----------
-[0](UI.xml#L1844)|regular - with human or default input, no recommendation
-[1](UI.xml#L1848)|highlighted - without human input and with recommendation
-[2](UI.xml#L1852)|warning - with human or default input and with recommendation
+[0](UI.xml#L1867)|regular - with human or default input, no recommendation
+[1](UI.xml#L1871)|highlighted - without human input and with recommendation
+[2](UI.xml#L1875)|warning - with human or default input and with recommendation
 
 <a name="RecommendationListType"></a>
-## [RecommendationListType](UI.xml#L1867)
+## [RecommendationListType](UI.xml#L1890)
 Reference to a recommendation list
 
 A recommendation consists of one or more values for editable fields plus a rank between 0.0 and 9.9, with 9.9 being the best recommendation.
 
 Property|Type|Description
 :-------|:---|:----------
-[CollectionPath](UI.xml#L1872)|String|Resource path of a collection of recommended values
-[RankProperty](UI.xml#L1875)|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
-[Binding](UI.xml#L1878)|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
+[CollectionPath](UI.xml#L1895)|String|Resource path of a collection of recommended values
+[RankProperty](UI.xml#L1898)|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
+[Binding](UI.xml#L1901)|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
 
 <a name="RecommendationBinding"></a>
-## [RecommendationBinding](UI.xml#L1883)
+## [RecommendationBinding](UI.xml#L1906)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[LocalDataProperty](UI.xml#L1884)|PropertyPath|Path to editable property for which recommended values exist
-[ValueListProperty](UI.xml#L1887)|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
+[LocalDataProperty](UI.xml#L1907)|PropertyPath|Path to editable property for which recommended values exist
+[ValueListProperty](UI.xml#L1910)|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
 
 <a name="ActionName"></a>
-## [ActionName](UI.xml#L1911)
+## [ActionName](UI.xml#L1934)
 **Type:** String
 
 Name of an Action, Function, ActionImport, or FunctionImport in scope

--- a/vocabularies/UI.md
+++ b/vocabularies/UI.md
@@ -24,60 +24,58 @@ Term|Type|Description
 [Identification](UI.xml#L115)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="Identification"></a>Collection of fields identifying the object
 [Badge](UI.xml#L120)|[BadgeType](#BadgeType)|<a name="Badge"></a>Information usually displayed in the form of a business card
 [LineItem](UI.xml#L147)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="LineItem"></a>Collection of data fields for representation in a table or list
-[ApplyRecursiveHierarchy](UI.xml#L152) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|<a name="ApplyRecursiveHierarchy"></a>Qualifier of the recursive hierarchy that should be applied to a UI.LineItem<br>Variant 2 for hierarchical LineItems
-[HierarchicalLineItem](UI.xml#L161) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|<a name="HierarchicalLineItem"></a>Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier<br>Variant 3 for hierarchical LineItems
-[StatusInfo](UI.xml#L169)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="StatusInfo"></a>Collection of data fields describing the status of an entity
-[FieldGroup](UI.xml#L174)|[FieldGroupType](#FieldGroupType)|<a name="FieldGroup"></a>Group of fields with an optional label
-[ConnectedFields](UI.xml#L188)|[ConnectedFieldsType](#ConnectedFieldsType)|<a name="ConnectedFields"></a>Group of semantically connected fields with a representation template and an optional label ([Example](UI.xml#L190))
-[GeoLocations](UI.xml#L253)|\[[GeoLocationType](#GeoLocationType)\]|<a name="GeoLocations"></a>Collection of geographic locations
-[GeoLocation](UI.xml#L257)|[GeoLocationType](#GeoLocationType)|<a name="GeoLocation"></a>Geographic location
-[Contacts](UI.xml#L277)|\[AnnotationPath\]|<a name="Contacts"></a>Collection of contacts<br>Each collection item MUST reference an annotation of a Communication.Contact<br>Allowed terms:<ul><li>[Contact](Communication.md#Contact)</li></ul>
-[MediaResource](UI.xml#L288)|[MediaResourceType](#MediaResourceType)|<a name="MediaResource"></a>Properties that describe a media resource<br>Either `Url` or `Stream` MUST be present, and never both.
-[DataPoint](UI.xml#L368)|[DataPointType](#DataPointType)|<a name="DataPoint"></a>Visualization of a single point of data, typically a number; may also be textual, e.g. a status value
-[KPI](UI.xml#L676)|[KPIType](#KPIType)|<a name="KPI"></a>A Key Performance Indicator (KPI) bundles a SelectionVariant and a DataPoint, and provides details for progressive disclosure
-[Chart](UI.xml#L722)|[ChartDefinitionType](#ChartDefinitionType)|<a name="Chart"></a>Visualization of multiple data points
-[ValueCriticality](UI.xml#L946) *([Experimental](Common.md#Experimental))*|\[[ValueCriticalityType](#ValueCriticalityType)\]|<a name="ValueCriticality"></a>Assign criticalities to primitive values. This information can be used for semantic coloring.
-[CriticalityLabels](UI.xml#L959) *([Experimental](Common.md#Experimental))*|\[[CriticalityLabelType](#CriticalityLabelType)\]|<a name="CriticalityLabels"></a>Assign labels to criticalities. This information can be used for semantic coloring. When applied to a property, a label for a criticality must be provided, if more than one value of the annotated property has been assigned to the same criticality. There must be no more than one label per criticality.
-[SelectionFields](UI.xml#L980)|\[PropertyPath\]|<a name="SelectionFields"></a>Properties that might be relevant for filtering a collection of entities of this type
-[Facets](UI.xml#L987)|\[[Facet](#Facet)\]|<a name="Facets"></a>Collection of facets
-[HeaderFacets](UI.xml#L991)|\[[Facet](#Facet)\]|<a name="HeaderFacets"></a>Facets for additional object header information
-[QuickViewFacets](UI.xml#L995)|\[[Facet](#Facet)\]|<a name="QuickViewFacets"></a>Facets that may be used for a quick overview of the object
-[QuickCreateFacets](UI.xml#L999)|\[[Facet](#Facet)\]|<a name="QuickCreateFacets"></a>Facets that may be used for a (quick) create of the object
-[FilterFacets](UI.xml#L1003)|\[[ReferenceFacet](#ReferenceFacet)\]|<a name="FilterFacets"></a>Facets that reference UI.FieldGroup annotations to group filterable fields
-[SelectionPresentationVariant](UI.xml#L1076)|[SelectionPresentationVariantType](#SelectionPresentationVariantType)|<a name="SelectionPresentationVariant"></a>A SelectionPresentationVariant bundles a Selection Variant and a Presentation Variant
-[PresentationVariant](UI.xml#L1100)|[PresentationVariantType](#PresentationVariantType)|<a name="PresentationVariant"></a>Defines how the result of a queried collection of entities is shaped and how this result is displayed
-[SelectionVariant](UI.xml#L1220)|[SelectionVariantType](#SelectionVariantType)|<a name="SelectionVariant"></a>A SelectionVariant denotes a combination of parameters and filters to query the annotated entity set
-[ThingPerspective](UI.xml#L1376)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ThingPerspective"></a>The annotated term is a Thing Perspective
-[IsSummary](UI.xml#L1379)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsSummary"></a>This Facet and all included Facets are the summary of the thing. At most one Facet of a thing can be tagged with this term
-[PartOfPreview](UI.xml#L1383)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="PartOfPreview"></a>This record and all included structural elements are part of the Thing preview<br>This term can be applied e.g. to UI.Facet and UI.DataField
-[Map](UI.xml#L1387)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Map"></a>Target MUST reference a UI.GeoLocation, Communication.Address or a collection of these
-[Gallery](UI.xml#L1391)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Gallery"></a>Target MUST reference a UI.MediaResource
-[IsImageURL](UI.xml#L1396)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImageURL"></a>Properties and terms annotated with this term MUST contain a valid URL referencing an resource with a MIME type image<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
-[IsImage](UI.xml#L1406) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
-[MultiLineText](UI.xml#L1417)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
-[Placeholder](UI.xml#L1422)|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
-[InputMask](UI.xml#L1427) *([Experimental](Common.md#Experimental))*|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
-[TextArrangement](UI.xml#L1461)|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
-[Note](UI.xml#L1484) *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
-[Importance](UI.xml#L1537)|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
-[Hidden](UI.xml#L1552)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
-[IsCopyAction](UI.xml#L1560) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
-[CreateHidden](UI.xml#L1572)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
-[UpdateHidden](UI.xml#L1577)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[DeleteHidden](UI.xml#L1582)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
-[HiddenFilter](UI.xml#L1587)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
-[AdaptationHidden](UI.xml#L1596) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
-[DataFieldDefault](UI.xml#L1602)|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
-[Criticality](UI.xml#L1827)|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
-[CriticalityCalculation](UI.xml#L1831)|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
-[Emphasized](UI.xml#L1835) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
-[OrderBy](UI.xml#L1841) *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
-[ParameterDefaultValue](UI.xml#L1847)|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
-[RecommendationState](UI.xml#L1853)|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
-[RecommendationList](UI.xml#L1883)|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
-[ExcludeFromNavigationContext](UI.xml#L1915)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
-[DoNotCheckScaleOfMeasuredQuantity](UI.xml#L1919) *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
-[LeadingEntitySet](UI.xml#L1929) *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
+[StatusInfo](UI.xml#L152)|\[[DataFieldAbstract](#DataFieldAbstract)\]|<a name="StatusInfo"></a>Collection of data fields describing the status of an entity
+[FieldGroup](UI.xml#L157)|[FieldGroupType](#FieldGroupType)|<a name="FieldGroup"></a>Group of fields with an optional label
+[ConnectedFields](UI.xml#L171)|[ConnectedFieldsType](#ConnectedFieldsType)|<a name="ConnectedFields"></a>Group of semantically connected fields with a representation template and an optional label ([Example](UI.xml#L173))
+[GeoLocations](UI.xml#L236)|\[[GeoLocationType](#GeoLocationType)\]|<a name="GeoLocations"></a>Collection of geographic locations
+[GeoLocation](UI.xml#L240)|[GeoLocationType](#GeoLocationType)|<a name="GeoLocation"></a>Geographic location
+[Contacts](UI.xml#L260)|\[AnnotationPath\]|<a name="Contacts"></a>Collection of contacts<br>Each collection item MUST reference an annotation of a Communication.Contact<br>Allowed terms:<ul><li>[Contact](Communication.md#Contact)</li></ul>
+[MediaResource](UI.xml#L271)|[MediaResourceType](#MediaResourceType)|<a name="MediaResource"></a>Properties that describe a media resource<br>Either `Url` or `Stream` MUST be present, and never both.
+[DataPoint](UI.xml#L351)|[DataPointType](#DataPointType)|<a name="DataPoint"></a>Visualization of a single point of data, typically a number; may also be textual, e.g. a status value
+[KPI](UI.xml#L659)|[KPIType](#KPIType)|<a name="KPI"></a>A Key Performance Indicator (KPI) bundles a SelectionVariant and a DataPoint, and provides details for progressive disclosure
+[Chart](UI.xml#L705)|[ChartDefinitionType](#ChartDefinitionType)|<a name="Chart"></a>Visualization of multiple data points
+[ValueCriticality](UI.xml#L929) *([Experimental](Common.md#Experimental))*|\[[ValueCriticalityType](#ValueCriticalityType)\]|<a name="ValueCriticality"></a>Assign criticalities to primitive values. This information can be used for semantic coloring.
+[CriticalityLabels](UI.xml#L942) *([Experimental](Common.md#Experimental))*|\[[CriticalityLabelType](#CriticalityLabelType)\]|<a name="CriticalityLabels"></a>Assign labels to criticalities. This information can be used for semantic coloring. When applied to a property, a label for a criticality must be provided, if more than one value of the annotated property has been assigned to the same criticality. There must be no more than one label per criticality.
+[SelectionFields](UI.xml#L963)|\[PropertyPath\]|<a name="SelectionFields"></a>Properties that might be relevant for filtering a collection of entities of this type
+[Facets](UI.xml#L970)|\[[Facet](#Facet)\]|<a name="Facets"></a>Collection of facets
+[HeaderFacets](UI.xml#L974)|\[[Facet](#Facet)\]|<a name="HeaderFacets"></a>Facets for additional object header information
+[QuickViewFacets](UI.xml#L978)|\[[Facet](#Facet)\]|<a name="QuickViewFacets"></a>Facets that may be used for a quick overview of the object
+[QuickCreateFacets](UI.xml#L982)|\[[Facet](#Facet)\]|<a name="QuickCreateFacets"></a>Facets that may be used for a (quick) create of the object
+[FilterFacets](UI.xml#L986)|\[[ReferenceFacet](#ReferenceFacet)\]|<a name="FilterFacets"></a>Facets that reference UI.FieldGroup annotations to group filterable fields
+[SelectionPresentationVariant](UI.xml#L1059)|[SelectionPresentationVariantType](#SelectionPresentationVariantType)|<a name="SelectionPresentationVariant"></a>A SelectionPresentationVariant bundles a Selection Variant and a Presentation Variant
+[PresentationVariant](UI.xml#L1083)|[PresentationVariantType](#PresentationVariantType)|<a name="PresentationVariant"></a>Defines how the result of a queried collection of entities is shaped and how this result is displayed
+[SelectionVariant](UI.xml#L1200)|[SelectionVariantType](#SelectionVariantType)|<a name="SelectionVariant"></a>A SelectionVariant denotes a combination of parameters and filters to query the annotated entity set
+[ThingPerspective](UI.xml#L1356)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ThingPerspective"></a>The annotated term is a Thing Perspective
+[IsSummary](UI.xml#L1359)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsSummary"></a>This Facet and all included Facets are the summary of the thing. At most one Facet of a thing can be tagged with this term
+[PartOfPreview](UI.xml#L1363)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="PartOfPreview"></a>This record and all included structural elements are part of the Thing preview<br>This term can be applied e.g. to UI.Facet and UI.DataField
+[Map](UI.xml#L1367)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Map"></a>Target MUST reference a UI.GeoLocation, Communication.Address or a collection of these
+[Gallery](UI.xml#L1371)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Gallery"></a>Target MUST reference a UI.MediaResource
+[IsImageURL](UI.xml#L1376)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImageURL"></a>Properties and terms annotated with this term MUST contain a valid URL referencing an resource with a MIME type image<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
+[IsImage](UI.xml#L1386) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsImage"></a>Properties annotated with this term MUST be a stream property annotated with a MIME type image. Entity types annotated with this term MUST be a media entity type annotated with a MIME type image.<br>Can be annotated with:<ul><li>[IsNaturalPerson](Common.md#IsNaturalPerson)</li></ul>
+[MultiLineText](UI.xml#L1397)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="MultiLineText"></a>Properties and parameters annotated with this annotation should be rendered as multi-line text (e.g. text area)
+[Placeholder](UI.xml#L1402)|String|<a name="Placeholder"></a>A short, human-readable text that gives a hint or an example to help the user with data entry
+[InputMask](UI.xml#L1407) *([Experimental](Common.md#Experimental))*|[InputMaskType](#InputMaskType)|<a name="InputMask"></a>Properties or parameters annotated with this term will get a mask in edit mode<br>Input masks improve readability and help to enter data correctly. So, masks can be especially useful for input fields that have a fixed pattern, e.g. DUNS numbers or similar. [Here](../examples/UI.InputMask-sample.xml) you can find an example for this annotation
+[TextArrangement](UI.xml#L1441)|[TextArrangementType](#TextArrangementType)|<a name="TextArrangement"></a>Describes the arrangement of a code or ID value and its text<br><p>This term annotates one of the following:</p> <ol type="1"> <li>a <a href="Common.md#Text"><code>Common.Text</code></a> annotation of the code or ID property where the annotation value is the text</li> <li>an entity type, this has the same effect as annotating all <code>Common.Text</code> annotations of properties of that entity type.</li> </ol> 
+[Note](UI.xml#L1464) *([Experimental](Common.md#Experimental))*|[NoteType](#NoteType)|<a name="Note"></a>Visualization of a note attached to an entity<br>Administrative data is given by the annotations [`Common.CreatedBy`](Common.md#CreatedBy), [`Common.CreatedAt`](Common.md#CreatedAt), [`Common.ChangedBy`](Common.md#ChangedBy), [`Common.ChangedAt`](Common.md#ChangedAt) on the same entity type.
+[Importance](UI.xml#L1517)|[ImportanceType](#ImportanceType)|<a name="Importance"></a>Expresses the importance of e.g. a DataField or an annotation
+[Hidden](UI.xml#L1532)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Hidden"></a>Properties or facets (see UI.Facet) annotated with this term will not be rendered if the annotation evaluates to true.<br>Hidden properties usually carry technical information that is used for application control and is of no direct interest to end users. The annotation value may be an expression to dynamically hide or render the annotated feature. If a navigation property is annotated with `Hidden` true, all subsequent parts are hidden - independent of their own potential `Hidden` annotations.
+[IsCopyAction](UI.xml#L1540) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="IsCopyAction"></a>The annotated [`DataFieldForAction`](#DataFieldForAction) record references an action that deep-copies an instance of the annotated entity type<br>The referenced action MUST be bound to the annotated entity type and MUST create a new instance of the same entity type as a deep copy of the bound instance. Upon successful completion, the response MUST contain a `Location` header that contains the edit URL or read URL of the created entity, and the response MUST be either `201 Created` and a representation of the created entity, or `204 No Content` if the request included a `Prefer` header with a value of `return=minimal` and did not include the system query options `$select` and `$expand`.
+[CreateHidden](UI.xml#L1552)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="CreateHidden"></a>EntitySets annotated with this term can control the visibility of the Create operation dynamically<br>The annotation value should be a path to another property from a related entity.
+[UpdateHidden](UI.xml#L1557)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="UpdateHidden"></a>EntitySets annotated with this term can control the visibility of the Edit/Save operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[DeleteHidden](UI.xml#L1562)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="DeleteHidden"></a>EntitySets annotated with this term can control the visibility of the Delete operation dynamically<br>The annotation value should be a path to another property from the same or a related entity.
+[HiddenFilter](UI.xml#L1567)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="HiddenFilter"></a>Properties annotated with this term will not be rendered as filter criteria if the annotation evaluates to true.<br>Properties annotated with `HiddenFilter` are intended as parts of a `$filter` expression that cannot be directly influenced by end users. The properties will be rendered in all other places, e.g. table columns or form fields. This is in contrast to properties annotated with [Hidden](#Hidden) that are not rendered at all. If a navigation property is annotated with `HiddenFilter` true, all subsequent parts are hidden in filter - independent of their own potential `HiddenFilter` annotations.
+[AdaptationHidden](UI.xml#L1576) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="AdaptationHidden"></a>Properties or entities annotated with this term can't be used for UI adaptation/configuration/personalization<br>The tagged elements can only be used in UI based on metadata, annnotations or code.
+[DataFieldDefault](UI.xml#L1582)|[DataFieldAbstract](#DataFieldAbstract)|<a name="DataFieldDefault"></a>Default representation of a property as a datafield, e.g. when the property is added as a table column or form field via personalization<br>Only concrete subtypes of [DataFieldAbstract](#DataFieldAbstract) can be used for a DataFieldDefault. For type [DataField](#DataField) and its subtypes the annotation target SHOULD be the same property that is referenced via a path expression in the `Value` of the datafield.
+[Criticality](UI.xml#L1807)|[CriticalityType](#CriticalityType)|<a name="Criticality"></a>Service-calculated criticality, alternative to UI.CriticalityCalculation
+[CriticalityCalculation](UI.xml#L1811)|[CriticalityCalculationType](#CriticalityCalculationType)|<a name="CriticalityCalculation"></a>Parameters for client-calculated criticality, alternative to UI.Criticality
+[Emphasized](UI.xml#L1815) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="Emphasized"></a>Highlight something that is of special interest<br>The usage of a property or operation should be highlighted as it's of special interest for the end user
+[OrderBy](UI.xml#L1821) *([Experimental](Common.md#Experimental))*|PropertyPath|<a name="OrderBy"></a>Sort by the referenced property instead of by the annotated property<br>Example: annotated property `SizeCode` has string values XS, S, M, L, XL, referenced property SizeOrder has numeric values -2, -1, 0, 1, 2. Numeric ordering by SizeOrder will be more understandable than lexicographic ordering by SizeCode.
+[ParameterDefaultValue](UI.xml#L1827)|PrimitiveType?|<a name="ParameterDefaultValue"></a>Define default values for action parameters<br>For unbound actions the default value can either be a constant expression, or a dynamic expression using absolute paths, e.g. singletons or function import results. Whereas for bound actions the bound entity and its properties and associated properties can be used as default values
+[RecommendationState](UI.xml#L1833)|[RecommendationStateType](#RecommendationStateType)|<a name="RecommendationState"></a>Indicates whether a field contains or has a recommended value<br>Intelligent systems can help users by recommending input the user may "prefer".
+[RecommendationList](UI.xml#L1863)|[RecommendationListType](#RecommendationListType)|<a name="RecommendationList"></a>Specifies how to get a list of recommended values for a property or parameter<br>Intelligent systems can help users by recommending input the user may "prefer".
+[ExcludeFromNavigationContext](UI.xml#L1895)|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="ExcludeFromNavigationContext"></a>The contents of this property must not be propagated to the app-to-app navigation context
+[DoNotCheckScaleOfMeasuredQuantity](UI.xml#L1899) *([Experimental](Common.md#Experimental))*|Boolean|<a name="DoNotCheckScaleOfMeasuredQuantity"></a>Do not check the number of fractional digits of the annotated measured quantity<br>The annotated property contains a measured quantity, and the user may enter more fractional digits than defined for the corresponding unit of measure.<br/>This switches off the validation of user input with respect to decimals.
+[LeadingEntitySet](UI.xml#L1909) *([Experimental](Common.md#Experimental))*|String|<a name="LeadingEntitySet"></a>The referenced entity set is the preferred starting point for UIs using this service
 
 <a name="HeaderInfoType"></a>
 ## [HeaderInfoType](UI.xml#L68)
@@ -108,137 +106,137 @@ Property|Type|Description
 [SecondaryInfo](UI.xml#L142)|[DataField?](#DataField)|Additional information on the business card
 
 <a name="FieldGroupType"></a>
-## [FieldGroupType](UI.xml#L178)
+## [FieldGroupType](UI.xml#L161)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L179)|String?|Label for the field group
-[Data](UI.xml#L183)|\[[DataFieldAbstract](#DataFieldAbstract)\]|Collection of data fields
+[Label](UI.xml#L162)|String?|Label for the field group
+[Data](UI.xml#L166)|\[[DataFieldAbstract](#DataFieldAbstract)\]|Collection of data fields
 
 <a name="ConnectedFieldsType"></a>
-## [ConnectedFieldsType](UI.xml#L215)
+## [ConnectedFieldsType](UI.xml#L198)
 Group of semantically connected fields with a representation template and an optional label
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L217)|String?|Label for the connected fields
-[Template](UI.xml#L221)|String|Template for representing the connected fields<br>Template variables are identifiers enclosed in curly braces, e.g. `{MaterialName} - {MaterialClassName}`. The `Data` collection assigns values to the template variables.
-[Data](UI.xml#L226)|[Dictionary](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Dictionary)|Dictionary of template variables<br>Each template variable used in `Template` must be assigned a value here. The value must be of type [DataFieldAbstract](#DataFieldAbstract)
+[Label](UI.xml#L200)|String?|Label for the connected fields
+[Template](UI.xml#L204)|String|Template for representing the connected fields<br>Template variables are identifiers enclosed in curly braces, e.g. `{MaterialName} - {MaterialClassName}`. The `Data` collection assigns values to the template variables.
+[Data](UI.xml#L209)|[Dictionary](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Dictionary)|Dictionary of template variables<br>Each template variable used in `Template` must be assigned a value here. The value must be of type [DataFieldAbstract](#DataFieldAbstract)
 
 <a name="GeoLocationType"></a>
-## [GeoLocationType](UI.xml#L261)
+## [GeoLocationType](UI.xml#L244)
 Properties that define a geographic location
 
 Property|Type|Description
 :-------|:---|:----------
-[Latitude](UI.xml#L263)|Double?|Geographic latitude
-[Longitude](UI.xml#L266)|Double?|Geographic longitude
-[Location](UI.xml#L269)|GeographyPoint?|A point in a round-earth coordinate system
-[Address](UI.xml#L272)|[AddressType?](Communication.md#AddressType)|vCard-style address
+[Latitude](UI.xml#L246)|Double?|Geographic latitude
+[Longitude](UI.xml#L249)|Double?|Geographic longitude
+[Location](UI.xml#L252)|GeographyPoint?|A point in a round-earth coordinate system
+[Address](UI.xml#L255)|[AddressType?](Communication.md#AddressType)|vCard-style address
 
 <a name="MediaResourceType"></a>
-## [MediaResourceType](UI.xml#L293)
+## [MediaResourceType](UI.xml#L276)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Url](UI.xml#L294)|URL?|URL of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[Stream](UI.xml#L303) *([Experimental](Common.md#Experimental))*|Stream?|Stream of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[ContentType](UI.xml#L312)|MediaType?|Content type, such as application/pdf, video/x-flv, image/jpeg
-[ByteSize](UI.xml#L316)|Int64?|Resource size in bytes
-[ChangedAt](UI.xml#L319)|DateTimeOffset?|Date of last change
-[Thumbnail](UI.xml#L322)|[ImageType?](#ImageType)|Thumbnail image
-[Title](UI.xml#L325)|[DataField?](#DataField)|Resource title
-[Description](UI.xml#L328)|[DataField?](#DataField)|Resource description
+[Url](UI.xml#L277)|URL?|URL of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[Stream](UI.xml#L286) *([Experimental](Common.md#Experimental))*|Stream?|Stream of media resource<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[ContentType](UI.xml#L295)|MediaType?|Content type, such as application/pdf, video/x-flv, image/jpeg
+[ByteSize](UI.xml#L299)|Int64?|Resource size in bytes
+[ChangedAt](UI.xml#L302)|DateTimeOffset?|Date of last change
+[Thumbnail](UI.xml#L305)|[ImageType?](#ImageType)|Thumbnail image
+[Title](UI.xml#L308)|[DataField?](#DataField)|Resource title
+[Description](UI.xml#L311)|[DataField?](#DataField)|Resource description
 
 <a name="ImageType"></a>
-## [ImageType](UI.xml#L332)
+## [ImageType](UI.xml#L315)
 Properties that describe an image
 
 Either `Url` or `Stream` MUST be present, and never both.
 
 Property|Type|Description
 :-------|:---|:----------
-[Url](UI.xml#L335)|URL|URL of image
-[Stream](UI.xml#L339) *([Experimental](Common.md#Experimental))*|Stream?|Stream of image<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[Width](UI.xml#L348)|String?|Width of image
-[Height](UI.xml#L351)|String?|Height of image
+[Url](UI.xml#L318)|URL|URL of image
+[Stream](UI.xml#L322) *([Experimental](Common.md#Experimental))*|Stream?|Stream of image<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[Width](UI.xml#L331)|String?|Width of image
+[Height](UI.xml#L334)|String?|Height of image
 
 <a name="DataPointType"></a>
-## [DataPointType](UI.xml#L372)
+## [DataPointType](UI.xml#L355)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L373)|String?|Title of the data point
-[Description](UI.xml#L377)|String?|Short description
-[LongDescription](UI.xml#L381)|String?|Full description
-[Value](UI.xml#L385)|PrimitiveType|Numeric value<br>The value is typically provided via a `Path` construct. The path MUST lead to a direct property of the same entity type or a property of a complex property (recursively) of that entity type, navigation segments are not allowed.<br/>It could be annotated with either `UoM.ISOCurrency` or `UoM.Unit`. Percentage values are annotated with `UoM.Unit = '%'`. A renderer should take an optional `Common.Text` annotation into consideration.
-[TargetValue](UI.xml#L397)|PrimitiveType?|Target value
-[ForecastValue](UI.xml#L400)|PrimitiveType?|Forecast value
-[MinimumValue](UI.xml#L403)|Decimal?|Minimum value (for output rendering)
-[MaximumValue](UI.xml#L406)|Decimal?|Maximum value (for output rendering)
-[ValueFormat](UI.xml#L409)|[NumberFormat?](#NumberFormat)|Number format
-[Visualization](UI.xml#L412)|[VisualizationType?](#VisualizationType)|Preferred visualization
-[SampleSize](UI.xml#L415)|PrimitiveType?|Sample size used for the determination of the data point; should contain just integer value as Edm.Byte, Edm.SByte, Edm.Intxx, and Edm.Decimal with scale 0.
-[ReferencePeriod](UI.xml#L422)|[ReferencePeriod?](#ReferencePeriod)|Reference period
-[Criticality](UI.xml#L425)|[CriticalityType?](#CriticalityType)|Service-calculated criticality, alternative to CriticalityCalculation
-[CriticalityLabels](UI.xml#L428)|AnnotationPath?|Custom labels for the criticality legend. Annotation path MUST end in UI.CriticalityLabels<br>Allowed terms:<ul><li>[CriticalityLabels](#CriticalityLabels)</li></ul>
-[CriticalityRepresentation](UI.xml#L436) *([Experimental](Common.md#Experimental))*|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[CriticalityCalculation](UI.xml#L440)|[CriticalityCalculationType?](#CriticalityCalculationType)|Parameters for client-calculated criticality, alternative to Criticality
-[Trend](UI.xml#L443)|[TrendType?](#TrendType)|Service-calculated trend, alternative to TrendCalculation
-[TrendCalculation](UI.xml#L446)|[TrendCalculationType?](#TrendCalculationType)|Parameters for client-calculated trend, alternative to Trend
-[Responsible](UI.xml#L449)|[ContactType?](Communication.md#ContactType)|Contact person
+[Title](UI.xml#L356)|String?|Title of the data point
+[Description](UI.xml#L360)|String?|Short description
+[LongDescription](UI.xml#L364)|String?|Full description
+[Value](UI.xml#L368)|PrimitiveType|Numeric value<br>The value is typically provided via a `Path` construct. The path MUST lead to a direct property of the same entity type or a property of a complex property (recursively) of that entity type, navigation segments are not allowed.<br/>It could be annotated with either `UoM.ISOCurrency` or `UoM.Unit`. Percentage values are annotated with `UoM.Unit = '%'`. A renderer should take an optional `Common.Text` annotation into consideration.
+[TargetValue](UI.xml#L380)|PrimitiveType?|Target value
+[ForecastValue](UI.xml#L383)|PrimitiveType?|Forecast value
+[MinimumValue](UI.xml#L386)|Decimal?|Minimum value (for output rendering)
+[MaximumValue](UI.xml#L389)|Decimal?|Maximum value (for output rendering)
+[ValueFormat](UI.xml#L392)|[NumberFormat?](#NumberFormat)|Number format
+[Visualization](UI.xml#L395)|[VisualizationType?](#VisualizationType)|Preferred visualization
+[SampleSize](UI.xml#L398)|PrimitiveType?|Sample size used for the determination of the data point; should contain just integer value as Edm.Byte, Edm.SByte, Edm.Intxx, and Edm.Decimal with scale 0.
+[ReferencePeriod](UI.xml#L405)|[ReferencePeriod?](#ReferencePeriod)|Reference period
+[Criticality](UI.xml#L408)|[CriticalityType?](#CriticalityType)|Service-calculated criticality, alternative to CriticalityCalculation
+[CriticalityLabels](UI.xml#L411)|AnnotationPath?|Custom labels for the criticality legend. Annotation path MUST end in UI.CriticalityLabels<br>Allowed terms:<ul><li>[CriticalityLabels](#CriticalityLabels)</li></ul>
+[CriticalityRepresentation](UI.xml#L419) *([Experimental](Common.md#Experimental))*|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[CriticalityCalculation](UI.xml#L423)|[CriticalityCalculationType?](#CriticalityCalculationType)|Parameters for client-calculated criticality, alternative to Criticality
+[Trend](UI.xml#L426)|[TrendType?](#TrendType)|Service-calculated trend, alternative to TrendCalculation
+[TrendCalculation](UI.xml#L429)|[TrendCalculationType?](#TrendCalculationType)|Parameters for client-calculated trend, alternative to Trend
+[Responsible](UI.xml#L432)|[ContactType?](Communication.md#ContactType)|Contact person
 
 <a name="NumberFormat"></a>
-## [NumberFormat](UI.xml#L454)
+## [NumberFormat](UI.xml#L437)
 Describes how to visualise a number
 
 Property|Type|Description
 :-------|:---|:----------
-[ScaleFactor](UI.xml#L456)|Decimal?|Display value in *ScaleFactor* units, e.g. 1000 for k (kilo), 1e6 for M (Mega)
-[NumberOfFractionalDigits](UI.xml#L459)|Byte?|Number of fractional digits of the scaled value to be visualized
+[ScaleFactor](UI.xml#L439)|Decimal?|Display value in *ScaleFactor* units, e.g. 1000 for k (kilo), 1e6 for M (Mega)
+[NumberOfFractionalDigits](UI.xml#L442)|Byte?|Number of fractional digits of the scaled value to be visualized
 
 <a name="VisualizationType"></a>
-## [VisualizationType](UI.xml#L464)
+## [VisualizationType](UI.xml#L447)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Number](UI.xml#L465)|0|Visualize as a number
-[BulletChart](UI.xml#L468)|1|Visualize as bullet chart - requires TargetValue
-[Progress](UI.xml#L471)|2|Visualize as progress indicator - requires TargetValue
-[Rating](UI.xml#L474)|3|Visualize as partially or completely filled stars/hearts/... - requires TargetValue
-[Donut](UI.xml#L477)|4|Visualize as donut, optionally with missing segment - requires TargetValue
-[DeltaBulletChart](UI.xml#L480)|5|Visualize as delta bullet chart - requires TargetValue
+[Number](UI.xml#L448)|0|Visualize as a number
+[BulletChart](UI.xml#L451)|1|Visualize as bullet chart - requires TargetValue
+[Progress](UI.xml#L454)|2|Visualize as progress indicator - requires TargetValue
+[Rating](UI.xml#L457)|3|Visualize as partially or completely filled stars/hearts/... - requires TargetValue
+[Donut](UI.xml#L460)|4|Visualize as donut, optionally with missing segment - requires TargetValue
+[DeltaBulletChart](UI.xml#L463)|5|Visualize as delta bullet chart - requires TargetValue
 
 <a name="ReferencePeriod"></a>
-## [ReferencePeriod](UI.xml#L485)
+## [ReferencePeriod](UI.xml#L468)
 Reference period
 
 Property|Type|Description
 :-------|:---|:----------
-[Description](UI.xml#L487)|String?|Short description of the reference period
-[Start](UI.xml#L491)|DateTimeOffset?|Start of the reference period
-[End](UI.xml#L494)|DateTimeOffset?|End of the reference period
+[Description](UI.xml#L470)|String?|Short description of the reference period
+[Start](UI.xml#L474)|DateTimeOffset?|Start of the reference period
+[End](UI.xml#L477)|DateTimeOffset?|End of the reference period
 
 <a name="CriticalityType"></a>
-## [CriticalityType](UI.xml#L499)
+## [CriticalityType](UI.xml#L482)
 Criticality of a value or status, represented e.g. via semantic colors (https://experience.sap.com/fiori-design-web/foundation/colors/#semantic-colors)
 
 Member|Value|Description
 :-----|----:|:----------
-[VeryNegative](UI.xml#L501) *([Experimental](Common.md#Experimental))*|-1|Very negative / dark-red status - risk - out of stock - late
-[Neutral](UI.xml#L505)|0|Neutral / grey status - inactive - open - in progress
-[Negative](UI.xml#L508)|1|Negative / red status - attention - overload - alert
-[Critical](UI.xml#L511)|2|Critical / orange status - warning
-[Positive](UI.xml#L514)|3|Positive / green status - completed - available - on track - acceptable
-[VeryPositive](UI.xml#L517) *([Experimental](Common.md#Experimental))*|4|Very positive - above max stock - excess
-[Information](UI.xml#L521) *([Experimental](Common.md#Experimental))*|5|Information - noticable - informative
+[VeryNegative](UI.xml#L484) *([Experimental](Common.md#Experimental))*|-1|Very negative / dark-red status - risk - out of stock - late
+[Neutral](UI.xml#L488)|0|Neutral / grey status - inactive - open - in progress
+[Negative](UI.xml#L491)|1|Negative / red status - attention - overload - alert
+[Critical](UI.xml#L494)|2|Critical / orange status - warning
+[Positive](UI.xml#L497)|3|Positive / green status - completed - available - on track - acceptable
+[VeryPositive](UI.xml#L500) *([Experimental](Common.md#Experimental))*|4|Very positive - above max stock - excess
+[Information](UI.xml#L504) *([Experimental](Common.md#Experimental))*|5|Information - noticable - informative
 
 <a name="CriticalityCalculationType"></a>
-## [CriticalityCalculationType](UI.xml#L527): [CriticalityThresholdsType](#CriticalityThresholdsType)
+## [CriticalityCalculationType](UI.xml#L510): [CriticalityThresholdsType](#CriticalityThresholdsType)
 Describes how to calculate the criticality of a value depending on the improvement direction
 
 
@@ -275,19 +273,19 @@ Thresholds are optional. For unassigned values, defaults are determined in this 
 
 Property|Type|Description
 :-------|:---|:----------
-[*AcceptanceRangeLowValue*](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
-[*AcceptanceRangeHighValue*](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
-[*ToleranceRangeLowValue*](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
-[*ToleranceRangeHighValue*](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
-[*DeviationRangeLowValue*](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
-[*DeviationRangeHighValue*](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
-[ReferenceValue](UI.xml#L562) *([Experimental](Common.md#Experimental))*|PrimitiveType?|Reference value for the calculation, e.g. number of sales for the last year
-[IsRelativeDifference](UI.xml#L566) *([Experimental](Common.md#Experimental))*|Boolean|Calculate with a relative difference
-[ImprovementDirection](UI.xml#L570)|[ImprovementDirectionType](#ImprovementDirectionType)|Describes in which direction the value improves
-[ConstantThresholds](UI.xml#L573) *([Experimental](Common.md#Experimental))*|\[[LevelThresholdsType](#LevelThresholdsType)\]|List of thresholds depending on the aggregation level as a set of constant values<br>Constant thresholds shall only be used in order to refine constant values given for the data point overall (aggregation level with empty collection of property paths), but not if the thresholds are based on other measure elements.
+[*AcceptanceRangeLowValue*](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
+[*AcceptanceRangeHighValue*](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
+[*ToleranceRangeLowValue*](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
+[*ToleranceRangeHighValue*](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
+[*DeviationRangeLowValue*](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
+[*DeviationRangeHighValue*](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
+[ReferenceValue](UI.xml#L545) *([Experimental](Common.md#Experimental))*|PrimitiveType?|Reference value for the calculation, e.g. number of sales for the last year
+[IsRelativeDifference](UI.xml#L549) *([Experimental](Common.md#Experimental))*|Boolean|Calculate with a relative difference
+[ImprovementDirection](UI.xml#L553)|[ImprovementDirectionType](#ImprovementDirectionType)|Describes in which direction the value improves
+[ConstantThresholds](UI.xml#L556) *([Experimental](Common.md#Experimental))*|\[[LevelThresholdsType](#LevelThresholdsType)\]|List of thresholds depending on the aggregation level as a set of constant values<br>Constant thresholds shall only be used in order to refine constant values given for the data point overall (aggregation level with empty collection of property paths), but not if the thresholds are based on other measure elements.
 
 <a name="CriticalityThresholdsType"></a>
-## [CriticalityThresholdsType](UI.xml#L580)
+## [CriticalityThresholdsType](UI.xml#L563)
 Thresholds for calculating the criticality of a value
 
 **Derived Types:**
@@ -296,51 +294,51 @@ Thresholds for calculating the criticality of a value
 
 Property|Type|Description
 :-------|:---|:----------
-[AcceptanceRangeLowValue](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
-[AcceptanceRangeHighValue](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
-[ToleranceRangeLowValue](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
-[ToleranceRangeHighValue](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
-[DeviationRangeLowValue](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
-[DeviationRangeHighValue](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
+[AcceptanceRangeLowValue](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
+[AcceptanceRangeHighValue](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
+[ToleranceRangeLowValue](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
+[ToleranceRangeHighValue](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
+[DeviationRangeLowValue](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
+[DeviationRangeHighValue](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
 
 <a name="ImprovementDirectionType"></a>
-## [ImprovementDirectionType](UI.xml#L602)
+## [ImprovementDirectionType](UI.xml#L585)
 Describes which direction of a value change is seen as an improvement
 
 Member|Value|Description
 :-----|----:|:----------
-[Minimize](UI.xml#L604)|1|Lower is better
-[Target](UI.xml#L607)|2|Closer to the target is better
-[Maximize](UI.xml#L610)|3|Higher is better
+[Minimize](UI.xml#L587)|1|Lower is better
+[Target](UI.xml#L590)|2|Closer to the target is better
+[Maximize](UI.xml#L593)|3|Higher is better
 
 <a name="LevelThresholdsType"></a>
-## [LevelThresholdsType](UI.xml#L615): [CriticalityThresholdsType](#CriticalityThresholdsType) *([Experimental](Common.md#Experimental))*
+## [LevelThresholdsType](UI.xml#L598): [CriticalityThresholdsType](#CriticalityThresholdsType) *([Experimental](Common.md#Experimental))*
 Thresholds for an aggregation level
 
 Property|Type|Description
 :-------|:---|:----------
-[*AcceptanceRangeLowValue*](UI.xml#L582)|PrimitiveType?|Lowest value that is considered positive
-[*AcceptanceRangeHighValue*](UI.xml#L585)|PrimitiveType?|Highest value that is considered positive
-[*ToleranceRangeLowValue*](UI.xml#L588)|PrimitiveType?|Lowest value that is considered neutral
-[*ToleranceRangeHighValue*](UI.xml#L591)|PrimitiveType?|Highest value that is considered neutral
-[*DeviationRangeLowValue*](UI.xml#L594)|PrimitiveType?|Lowest value that is considered critical
-[*DeviationRangeHighValue*](UI.xml#L597)|PrimitiveType?|Highest value that is considered critical
-[AggregationLevel](UI.xml#L618)|\[PropertyPath\]|An unordered tuple of dimensions, i.e. properties which are intended to be used for grouping in aggregating requests. In analytical UIs, e.g. an analytical chart, the aggregation level typically corresponds to the visible dimensions.
+[*AcceptanceRangeLowValue*](UI.xml#L565)|PrimitiveType?|Lowest value that is considered positive
+[*AcceptanceRangeHighValue*](UI.xml#L568)|PrimitiveType?|Highest value that is considered positive
+[*ToleranceRangeLowValue*](UI.xml#L571)|PrimitiveType?|Lowest value that is considered neutral
+[*ToleranceRangeHighValue*](UI.xml#L574)|PrimitiveType?|Highest value that is considered neutral
+[*DeviationRangeLowValue*](UI.xml#L577)|PrimitiveType?|Lowest value that is considered critical
+[*DeviationRangeHighValue*](UI.xml#L580)|PrimitiveType?|Highest value that is considered critical
+[AggregationLevel](UI.xml#L601)|\[PropertyPath\]|An unordered tuple of dimensions, i.e. properties which are intended to be used for grouping in aggregating requests. In analytical UIs, e.g. an analytical chart, the aggregation level typically corresponds to the visible dimensions.
 
 <a name="TrendType"></a>
-## [TrendType](UI.xml#L623)
+## [TrendType](UI.xml#L606)
 The trend of a value
 
 Member|Value|Description
 :-----|----:|:----------
-[StrongUp](UI.xml#L625)|1|Value grows strongly
-[Up](UI.xml#L628)|2|Value grows
-[Sideways](UI.xml#L631)|3|Value does not significantly grow or shrink
-[Down](UI.xml#L634)|4|Value shrinks
-[StrongDown](UI.xml#L637)|5|Value shrinks strongly
+[StrongUp](UI.xml#L608)|1|Value grows strongly
+[Up](UI.xml#L611)|2|Value grows
+[Sideways](UI.xml#L614)|3|Value does not significantly grow or shrink
+[Down](UI.xml#L617)|4|Value shrinks
+[StrongDown](UI.xml#L620)|5|Value shrinks strongly
 
 <a name="TrendCalculationType"></a>
-## [TrendCalculationType](UI.xml#L642)
+## [TrendCalculationType](UI.xml#L625)
 Describes how to calculate the trend of a value
 
 
@@ -356,220 +354,220 @@ The trend is
 
 Property|Type|Description
 :-------|:---|:----------
-[ReferenceValue](UI.xml#L656)|PrimitiveType|Reference value for the calculation, e.g. number of sales for the last year
-[IsRelativeDifference](UI.xml#L659)|Boolean|Calculate with a relative difference
-[UpDifference](UI.xml#L662)|Decimal|Threshold for Up
-[StrongUpDifference](UI.xml#L665)|Decimal|Threshold for StrongUp
-[DownDifference](UI.xml#L668)|Decimal|Threshold for Down
-[StrongDownDifference](UI.xml#L671)|Decimal|Threshold for StrongDown
+[ReferenceValue](UI.xml#L639)|PrimitiveType|Reference value for the calculation, e.g. number of sales for the last year
+[IsRelativeDifference](UI.xml#L642)|Boolean|Calculate with a relative difference
+[UpDifference](UI.xml#L645)|Decimal|Threshold for Up
+[StrongUpDifference](UI.xml#L648)|Decimal|Threshold for StrongUp
+[DownDifference](UI.xml#L651)|Decimal|Threshold for Down
+[StrongDownDifference](UI.xml#L654)|Decimal|Threshold for StrongDown
 
 <a name="KPIType"></a>
-## [KPIType](UI.xml#L682)
+## [KPIType](UI.xml#L665)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L683)|String?|Optional identifier to reference this instance from an external context
-[ShortDescription](UI.xml#L688) *([Experimental](Common.md#Experimental))*|String?|Very short description
-[SelectionVariant](UI.xml#L693)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
-[DataPoint](UI.xml#L696)|[DataPointType](#DataPointType)|Data point, either specified inline or referencing another annotation via Path
-[AdditionalDataPoints](UI.xml#L699)|\[[DataPointType](#DataPointType)\]|Additional data points, either specified inline or referencing another annotation via Path<br>Additional data points are typically related to the main data point and provide complementing information or could be used for comparisons
-[Detail](UI.xml#L703)|[KPIDetailType?](#KPIDetailType)|Contains information about KPI details, especially drill-down presentations
+[ID](UI.xml#L666)|String?|Optional identifier to reference this instance from an external context
+[ShortDescription](UI.xml#L671) *([Experimental](Common.md#Experimental))*|String?|Very short description
+[SelectionVariant](UI.xml#L676)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
+[DataPoint](UI.xml#L679)|[DataPointType](#DataPointType)|Data point, either specified inline or referencing another annotation via Path
+[AdditionalDataPoints](UI.xml#L682)|\[[DataPointType](#DataPointType)\]|Additional data points, either specified inline or referencing another annotation via Path<br>Additional data points are typically related to the main data point and provide complementing information or could be used for comparisons
+[Detail](UI.xml#L686)|[KPIDetailType?](#KPIDetailType)|Contains information about KPI details, especially drill-down presentations
 
 <a name="KPIDetailType"></a>
-## [KPIDetailType](UI.xml#L707)
+## [KPIDetailType](UI.xml#L690)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[DefaultPresentationVariant](UI.xml#L708)|[PresentationVariantType?](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
-[AlternativePresentationVariants](UI.xml#L711)|\[[PresentationVariantType](#PresentationVariantType)\]|A list of alternative presentation variants, either specified inline or referencing another annotation via Path
-[SemanticObject](UI.xml#L714)|String?|Name of the Semantic Object. If not specified, use Semantic Object annotated at the property referenced in KPI/DataPoint/Value
-[Action](UI.xml#L717)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[DefaultPresentationVariant](UI.xml#L691)|[PresentationVariantType?](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
+[AlternativePresentationVariants](UI.xml#L694)|\[[PresentationVariantType](#PresentationVariantType)\]|A list of alternative presentation variants, either specified inline or referencing another annotation via Path
+[SemanticObject](UI.xml#L697)|String?|Name of the Semantic Object. If not specified, use Semantic Object annotated at the property referenced in KPI/DataPoint/Value
+[Action](UI.xml#L700)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
 
 <a name="ChartDefinitionType"></a>
-## [ChartDefinitionType](UI.xml#L726)
+## [ChartDefinitionType](UI.xml#L709)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L727)|String?|Title of the chart
-[Description](UI.xml#L731)|String?|Short description
-[ChartType](UI.xml#L735)|[ChartType](#ChartType)|Chart type
-[AxisScaling](UI.xml#L738)|[ChartAxisScalingType?](#ChartAxisScalingType)|Describes the scale of the chart value axes
-[Measures](UI.xml#L741)|\[PropertyPath\]|Measures of the chart, e.g. size and color in a bubble chart
-[DynamicMeasures](UI.xml#L745)|\[AnnotationPath\]|Dynamic properties introduced by annotations and used as measures of the chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[MeasureAttributes](UI.xml#L758)|\[[ChartMeasureAttributeType](#ChartMeasureAttributeType)\]|Describes Attributes for Measures. All Measures used in this collection must also be part of the Measures Property.
-[Dimensions](UI.xml#L763)|\[PropertyPath\]|Dimensions of the chart, e.g. x- and y-axis of a bubble chart
-[DimensionAttributes](UI.xml#L766)|\[[ChartDimensionAttributeType](#ChartDimensionAttributeType)\]|Describes Attributes for Dimensions. All Dimensions used in this collection must also be part of the Dimensions Property.
-[Actions](UI.xml#L771)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Available actions
+[Title](UI.xml#L710)|String?|Title of the chart
+[Description](UI.xml#L714)|String?|Short description
+[ChartType](UI.xml#L718)|[ChartType](#ChartType)|Chart type
+[AxisScaling](UI.xml#L721)|[ChartAxisScalingType?](#ChartAxisScalingType)|Describes the scale of the chart value axes
+[Measures](UI.xml#L724)|\[PropertyPath\]|Measures of the chart, e.g. size and color in a bubble chart
+[DynamicMeasures](UI.xml#L728)|\[AnnotationPath\]|Dynamic properties introduced by annotations and used as measures of the chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[MeasureAttributes](UI.xml#L741)|\[[ChartMeasureAttributeType](#ChartMeasureAttributeType)\]|Describes Attributes for Measures. All Measures used in this collection must also be part of the Measures Property.
+[Dimensions](UI.xml#L746)|\[PropertyPath\]|Dimensions of the chart, e.g. x- and y-axis of a bubble chart
+[DimensionAttributes](UI.xml#L749)|\[[ChartDimensionAttributeType](#ChartDimensionAttributeType)\]|Describes Attributes for Dimensions. All Dimensions used in this collection must also be part of the Dimensions Property.
+[Actions](UI.xml#L754)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Available actions
 
 <a name="ChartType"></a>
-## [ChartType](UI.xml#L776)
+## [ChartType](UI.xml#L759)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Column](UI.xml#L777)|0|
-[ColumnStacked](UI.xml#L778)|1|
-[ColumnDual](UI.xml#L779)|2|
-[ColumnStackedDual](UI.xml#L780)|3|
-[ColumnStacked100](UI.xml#L781)|4|
-[ColumnStackedDual100](UI.xml#L782)|5|
-[Bar](UI.xml#L783)|6|
-[BarStacked](UI.xml#L784)|7|
-[BarDual](UI.xml#L785)|8|
-[BarStackedDual](UI.xml#L786)|9|
-[BarStacked100](UI.xml#L787)|10|
-[BarStackedDual100](UI.xml#L788)|11|
-[Area](UI.xml#L789)|12|
-[AreaStacked](UI.xml#L790)|13|
-[AreaStacked100](UI.xml#L791)|14|
-[HorizontalArea](UI.xml#L792)|15|
-[HorizontalAreaStacked](UI.xml#L793)|16|
-[HorizontalAreaStacked100](UI.xml#L794)|17|
-[Line](UI.xml#L795)|18|
-[LineDual](UI.xml#L796)|19|
-[Combination](UI.xml#L797)|20|
-[CombinationStacked](UI.xml#L798)|21|
-[CombinationDual](UI.xml#L799)|22|
-[CombinationStackedDual](UI.xml#L800)|23|
-[HorizontalCombinationStacked](UI.xml#L801)|24|
-[Pie](UI.xml#L802)|25|
-[Donut](UI.xml#L803)|26|
-[Scatter](UI.xml#L804)|27|
-[Bubble](UI.xml#L805)|28|
-[Radar](UI.xml#L806)|29|
-[HeatMap](UI.xml#L807)|30|
-[TreeMap](UI.xml#L808)|31|
-[Waterfall](UI.xml#L809)|32|
-[Bullet](UI.xml#L810)|33|
-[VerticalBullet](UI.xml#L811)|34|
-[HorizontalWaterfall](UI.xml#L812)|35|
-[HorizontalCombinationDual](UI.xml#L813)|36|
-[HorizontalCombinationStackedDual](UI.xml#L814)|37|
-[Donut100](UI.xml#L815) *([Experimental](Common.md#Experimental))*|38|
+[Column](UI.xml#L760)|0|
+[ColumnStacked](UI.xml#L761)|1|
+[ColumnDual](UI.xml#L762)|2|
+[ColumnStackedDual](UI.xml#L763)|3|
+[ColumnStacked100](UI.xml#L764)|4|
+[ColumnStackedDual100](UI.xml#L765)|5|
+[Bar](UI.xml#L766)|6|
+[BarStacked](UI.xml#L767)|7|
+[BarDual](UI.xml#L768)|8|
+[BarStackedDual](UI.xml#L769)|9|
+[BarStacked100](UI.xml#L770)|10|
+[BarStackedDual100](UI.xml#L771)|11|
+[Area](UI.xml#L772)|12|
+[AreaStacked](UI.xml#L773)|13|
+[AreaStacked100](UI.xml#L774)|14|
+[HorizontalArea](UI.xml#L775)|15|
+[HorizontalAreaStacked](UI.xml#L776)|16|
+[HorizontalAreaStacked100](UI.xml#L777)|17|
+[Line](UI.xml#L778)|18|
+[LineDual](UI.xml#L779)|19|
+[Combination](UI.xml#L780)|20|
+[CombinationStacked](UI.xml#L781)|21|
+[CombinationDual](UI.xml#L782)|22|
+[CombinationStackedDual](UI.xml#L783)|23|
+[HorizontalCombinationStacked](UI.xml#L784)|24|
+[Pie](UI.xml#L785)|25|
+[Donut](UI.xml#L786)|26|
+[Scatter](UI.xml#L787)|27|
+[Bubble](UI.xml#L788)|28|
+[Radar](UI.xml#L789)|29|
+[HeatMap](UI.xml#L790)|30|
+[TreeMap](UI.xml#L791)|31|
+[Waterfall](UI.xml#L792)|32|
+[Bullet](UI.xml#L793)|33|
+[VerticalBullet](UI.xml#L794)|34|
+[HorizontalWaterfall](UI.xml#L795)|35|
+[HorizontalCombinationDual](UI.xml#L796)|36|
+[HorizontalCombinationStackedDual](UI.xml#L797)|37|
+[Donut100](UI.xml#L798) *([Experimental](Common.md#Experimental))*|38|
 
 <a name="ChartAxisScalingType"></a>
-## [ChartAxisScalingType](UI.xml#L821)
+## [ChartAxisScalingType](UI.xml#L804)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ScaleBehavior](UI.xml#L822)|[ChartAxisScaleBehaviorType](#ChartAxisScaleBehaviorType)|Scale is fixed or adapts automatically to rendered values
-[AutoScaleBehavior](UI.xml#L825)|[ChartAxisAutoScaleBehaviorType?](#ChartAxisAutoScaleBehaviorType)|Settings for automatic scaling
-[FixedScaleMultipleStackedMeasuresBoundaryValues](UI.xml#L828)|[FixedScaleMultipleStackedMeasuresBoundaryValuesType?](#FixedScaleMultipleStackedMeasuresBoundaryValuesType)|Boundary values for fixed scaling of a stacking chart type with multiple measures
+[ScaleBehavior](UI.xml#L805)|[ChartAxisScaleBehaviorType](#ChartAxisScaleBehaviorType)|Scale is fixed or adapts automatically to rendered values
+[AutoScaleBehavior](UI.xml#L808)|[ChartAxisAutoScaleBehaviorType?](#ChartAxisAutoScaleBehaviorType)|Settings for automatic scaling
+[FixedScaleMultipleStackedMeasuresBoundaryValues](UI.xml#L811)|[FixedScaleMultipleStackedMeasuresBoundaryValuesType?](#FixedScaleMultipleStackedMeasuresBoundaryValuesType)|Boundary values for fixed scaling of a stacking chart type with multiple measures
 
 <a name="ChartAxisScaleBehaviorType"></a>
-## [ChartAxisScaleBehaviorType](UI.xml#L833)
+## [ChartAxisScaleBehaviorType](UI.xml#L816)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[AutoScale](UI.xml#L834)|0|Value axes scale automatically
-[FixedScale](UI.xml#L837)|1|Fixed minimum and maximum values are applied, which are derived from the @UI.MeasureAttributes.DataPoint/MinimumValue and .../MaximumValue annotation by default. For stacking chart types with multiple measures, they are taken from ChartAxisScalingType/FixedScaleMultipleStackedMeasuresBoundaryValues.
+[AutoScale](UI.xml#L817)|0|Value axes scale automatically
+[FixedScale](UI.xml#L820)|1|Fixed minimum and maximum values are applied, which are derived from the @UI.MeasureAttributes.DataPoint/MinimumValue and .../MaximumValue annotation by default. For stacking chart types with multiple measures, they are taken from ChartAxisScalingType/FixedScaleMultipleStackedMeasuresBoundaryValues.
 
 <a name="ChartAxisAutoScaleBehaviorType"></a>
-## [ChartAxisAutoScaleBehaviorType](UI.xml#L846)
+## [ChartAxisAutoScaleBehaviorType](UI.xml#L829)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ZeroAlwaysVisible](UI.xml#L847)|Boolean|Forces the value axis to always display the zero value
-[DataScope](UI.xml#L850)|[ChartAxisAutoScaleDataScopeType](#ChartAxisAutoScaleDataScopeType)|Determines the automatic scaling
+[ZeroAlwaysVisible](UI.xml#L830)|Boolean|Forces the value axis to always display the zero value
+[DataScope](UI.xml#L833)|[ChartAxisAutoScaleDataScopeType](#ChartAxisAutoScaleDataScopeType)|Determines the automatic scaling
 
 <a name="ChartAxisAutoScaleDataScopeType"></a>
-## [ChartAxisAutoScaleDataScopeType](UI.xml#L855)
+## [ChartAxisAutoScaleDataScopeType](UI.xml#L838)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[DataSet](UI.xml#L856)|0|Minimum and maximum axes values are determined from the entire data set
-[VisibleData](UI.xml#L859)|1|Minimum and maximum axes values are determined from the currently visible data. Scrolling will change the scale.
+[DataSet](UI.xml#L839)|0|Minimum and maximum axes values are determined from the entire data set
+[VisibleData](UI.xml#L842)|1|Minimum and maximum axes values are determined from the currently visible data. Scrolling will change the scale.
 
 <a name="FixedScaleMultipleStackedMeasuresBoundaryValuesType"></a>
-## [FixedScaleMultipleStackedMeasuresBoundaryValuesType](UI.xml#L864)
+## [FixedScaleMultipleStackedMeasuresBoundaryValuesType](UI.xml#L847)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[MinimumValue](UI.xml#L865)|Decimal|Minimum value on value axes
-[MaximumValue](UI.xml#L868)|Decimal|Maximum value on value axes
+[MinimumValue](UI.xml#L848)|Decimal|Minimum value on value axes
+[MaximumValue](UI.xml#L851)|Decimal|Maximum value on value axes
 
 <a name="ChartDimensionAttributeType"></a>
-## [ChartDimensionAttributeType](UI.xml#L873)
+## [ChartDimensionAttributeType](UI.xml#L856)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Dimension](UI.xml#L874)|PropertyPath?|
-[Role](UI.xml#L875)|[ChartDimensionRoleType?](#ChartDimensionRoleType)|
-[HierarchyLevel](UI.xml#L876) *([Experimental](Common.md#Experimental))*|Int32?|For a dimension with a hierarchy, members are selected from this level. The root node of the hierarchy is at level 0.
-[ValuesForSequentialColorLevels](UI.xml#L880) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be assigned to levels of the same color.
-[EmphasizedValues](UI.xml#L884) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be emphasized.
-[EmphasisLabels](UI.xml#L888) *([Experimental](Common.md#Experimental))*|[EmphasisLabelType?](#EmphasisLabelType)|Assign a label to values with an emphasized representation. This is required, if more than one emphasized value has been specified.
+[Dimension](UI.xml#L857)|PropertyPath?|
+[Role](UI.xml#L858)|[ChartDimensionRoleType?](#ChartDimensionRoleType)|
+[HierarchyLevel](UI.xml#L859) *([Experimental](Common.md#Experimental))*|Int32?|For a dimension with a hierarchy, members are selected from this level. The root node of the hierarchy is at level 0.
+[ValuesForSequentialColorLevels](UI.xml#L863) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be assigned to levels of the same color.
+[EmphasizedValues](UI.xml#L867) *([Experimental](Common.md#Experimental))*|\[String\]|All values in this collection should be emphasized.
+[EmphasisLabels](UI.xml#L871) *([Experimental](Common.md#Experimental))*|[EmphasisLabelType?](#EmphasisLabelType)|Assign a label to values with an emphasized representation. This is required, if more than one emphasized value has been specified.
 
 <a name="ChartMeasureAttributeType"></a>
-## [ChartMeasureAttributeType](UI.xml#L894)
+## [ChartMeasureAttributeType](UI.xml#L877)
 Exactly one of `Measure` and `DynamicMeasure` must be present
 
 Property|Type|Description
 :-------|:---|:----------
-[Measure](UI.xml#L896)|PropertyPath?|
-[DynamicMeasure](UI.xml#L899)|AnnotationPath?|Dynamic property introduced by an annotation and used as a measure in a chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[Role](UI.xml#L912)|[ChartMeasureRoleType?](#ChartMeasureRoleType)|
-[DataPoint](UI.xml#L913)|AnnotationPath?|Annotation path MUST end in @UI.DataPoint and the data point's Value MUST be the same property as in Measure<br>Allowed terms:<ul><li>[DataPoint](#DataPoint)</li></ul>
-[UseSequentialColorLevels](UI.xml#L921) *([Experimental](Common.md#Experimental))*|Boolean|All measures for which this setting is true should be assigned to levels of the same color.
+[Measure](UI.xml#L879)|PropertyPath?|
+[DynamicMeasure](UI.xml#L882)|AnnotationPath?|Dynamic property introduced by an annotation and used as a measure in a chart<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being visualized according to the `UI.Chart` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[Role](UI.xml#L895)|[ChartMeasureRoleType?](#ChartMeasureRoleType)|
+[DataPoint](UI.xml#L896)|AnnotationPath?|Annotation path MUST end in @UI.DataPoint and the data point's Value MUST be the same property as in Measure<br>Allowed terms:<ul><li>[DataPoint](#DataPoint)</li></ul>
+[UseSequentialColorLevels](UI.xml#L904) *([Experimental](Common.md#Experimental))*|Boolean|All measures for which this setting is true should be assigned to levels of the same color.
 
 <a name="ChartDimensionRoleType"></a>
-## [ChartDimensionRoleType](UI.xml#L927)
+## [ChartDimensionRoleType](UI.xml#L910)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Category](UI.xml#L928)|0|
-[Series](UI.xml#L929)|1|
-[Category2](UI.xml#L930)|2|
+[Category](UI.xml#L911)|0|
+[Series](UI.xml#L912)|1|
+[Category2](UI.xml#L913)|2|
 
 <a name="ChartMeasureRoleType"></a>
-## [ChartMeasureRoleType](UI.xml#L933)
+## [ChartMeasureRoleType](UI.xml#L916)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Axis1](UI.xml#L934)|0|
-[Axis2](UI.xml#L935)|1|
-[Axis3](UI.xml#L936)|2|
+[Axis1](UI.xml#L917)|0|
+[Axis2](UI.xml#L918)|1|
+[Axis3](UI.xml#L919)|2|
 
 <a name="EmphasisLabelType"></a>
-## [EmphasisLabelType](UI.xml#L939) *([Experimental](Common.md#Experimental))*
+## [EmphasisLabelType](UI.xml#L922) *([Experimental](Common.md#Experimental))*
 Assigns a label to the set of emphasized values and optionally also for non-emphasized values. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[EmphasizedValuesLabel](UI.xml#L942)|String|
-[NonEmphasizedValuesLabel](UI.xml#L943)|String?|
+[EmphasizedValuesLabel](UI.xml#L925)|String|
+[NonEmphasizedValuesLabel](UI.xml#L926)|String?|
 
 <a name="ValueCriticalityType"></a>
-## [ValueCriticalityType](UI.xml#L950) *([Experimental](Common.md#Experimental))*
+## [ValueCriticalityType](UI.xml#L933) *([Experimental](Common.md#Experimental))*
 Assigns a fixed criticality to a primitive value. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[Value](UI.xml#L953)|PrimitiveType?|MUST be a fixed value of primitive type
-[Criticality](UI.xml#L956)|[CriticalityType?](#CriticalityType)|
+[Value](UI.xml#L936)|PrimitiveType?|MUST be a fixed value of primitive type
+[Criticality](UI.xml#L939)|[CriticalityType?](#CriticalityType)|
 
 <a name="CriticalityLabelType"></a>
-## [CriticalityLabelType](UI.xml#L970) *([Experimental](Common.md#Experimental))*
+## [CriticalityLabelType](UI.xml#L953) *([Experimental](Common.md#Experimental))*
 Assigns a label to a criticality. This information can be used for semantic coloring.
 
 Property|Type|Description
 :-------|:---|:----------
-[Criticality](UI.xml#L973)|[CriticalityType](#CriticalityType)|
-[Label](UI.xml#L974)|String|Criticality label
+[Criticality](UI.xml#L956)|[CriticalityType](#CriticalityType)|
+[Label](UI.xml#L957)|String|Criticality label
 
 <a name="Facet"></a>
-## [*Facet*](UI.xml#L1007)
+## [*Facet*](UI.xml#L990)
 Abstract base type for facets
 
 **Derived Types:**
@@ -579,8 +577,8 @@ Abstract base type for facets
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L1015)|String?|Facet label
-[ID](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Label](UI.xml#L998)|String?|Facet label
+[ID](UI.xml#L1002)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
 
 **Applicable Annotation Terms:**
 
@@ -588,14 +586,14 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="CollectionFacet"></a>
-## [CollectionFacet](UI.xml#L1023): [Facet](#Facet)
+## [CollectionFacet](UI.xml#L1006): [Facet](#Facet)
 Collection of facets
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1015)|String?|Facet label
-[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Facets](UI.xml#L1025)|\[[Facet](#Facet)\]|Nested facets. An empty collection may be used as a placeholder for content added via extension points.
+[*Label*](UI.xml#L998)|String?|Facet label
+[*ID*](UI.xml#L1002)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Facets](UI.xml#L1008)|\[[Facet](#Facet)\]|Nested facets. An empty collection may be used as a placeholder for content added via extension points.
 
 **Applicable Annotation Terms:**
 
@@ -603,14 +601,14 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="ReferenceFacet"></a>
-## [ReferenceFacet](UI.xml#L1029): [Facet](#Facet)
+## [ReferenceFacet](UI.xml#L1012): [Facet](#Facet)
 Facet that refers to a thing perspective, e.g. LineItem
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1015)|String?|Facet label
-[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Target](UI.xml#L1031)|AnnotationPath|Referenced information: Communication.Contact, Communication.Address, or a term that is tagged with UI.ThingPerspective, e.g. UI.StatusInfo, UI.LineItem, UI.Identification, UI.FieldGroup, UI.Badge<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Badge](#Badge)</li><li>[Chart](#Chart)</li><li>[Contacts](#Contacts)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li><li>[GeoLocation](#GeoLocation)</li><li>[GeoLocations](#GeoLocations)</li><li>[HeaderInfo](#HeaderInfo)</li><li>[Identification](#Identification)</li><li>[KPI](#KPI)</li><li>[LineItem](#LineItem)</li><li>[MediaResource](#MediaResource)</li><li>[Note](#Note)</li><li>[PresentationVariant](#PresentationVariant)</li><li>[SelectionFields](#SelectionFields)</li><li>[SelectionPresentationVariant](#SelectionPresentationVariant)</li><li>[StatusInfo](#StatusInfo)</li></ul>
+[*Label*](UI.xml#L998)|String?|Facet label
+[*ID*](UI.xml#L1002)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Target](UI.xml#L1014)|AnnotationPath|Referenced information: Communication.Contact, Communication.Address, or a term that is tagged with UI.ThingPerspective, e.g. UI.StatusInfo, UI.LineItem, UI.Identification, UI.FieldGroup, UI.Badge<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Badge](#Badge)</li><li>[Chart](#Chart)</li><li>[Contacts](#Contacts)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li><li>[GeoLocation](#GeoLocation)</li><li>[GeoLocations](#GeoLocations)</li><li>[HeaderInfo](#HeaderInfo)</li><li>[Identification](#Identification)</li><li>[KPI](#KPI)</li><li>[LineItem](#LineItem)</li><li>[MediaResource](#MediaResource)</li><li>[Note](#Note)</li><li>[PresentationVariant](#PresentationVariant)</li><li>[SelectionFields](#SelectionFields)</li><li>[SelectionPresentationVariant](#SelectionPresentationVariant)</li><li>[StatusInfo](#StatusInfo)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -618,15 +616,15 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="ReferenceURLFacet"></a>
-## [ReferenceURLFacet](UI.xml#L1058): [Facet](#Facet)
+## [ReferenceURLFacet](UI.xml#L1041): [Facet](#Facet)
 Facet that refers to a URL
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1015)|String?|Facet label
-[*ID*](UI.xml#L1019)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
-[Url](UI.xml#L1060)|URL|URL of referenced information<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](UI.xml#L1069)|MediaType?|Media type of referenced information
+[*Label*](UI.xml#L998)|String?|Facet label
+[*ID*](UI.xml#L1002)|String?|Unique identifier of a facet. ID should be stable, as long as the perceived semantics of the facet is unchanged.
+[Url](UI.xml#L1043)|URL|URL of referenced information<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](UI.xml#L1052)|MediaType?|Media type of referenced information
 
 **Applicable Annotation Terms:**
 
@@ -634,51 +632,51 @@ Property|Type|Description
 - [PartOfPreview](#PartOfPreview)
 
 <a name="SelectionPresentationVariantType"></a>
-## [SelectionPresentationVariantType](UI.xml#L1082)
+## [SelectionPresentationVariantType](UI.xml#L1065)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1083)|String?|Optional identifier to reference this variant from an external context
-[Text](UI.xml#L1088)|String?|Name of the bundling variant
-[SelectionVariant](UI.xml#L1092)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
-[PresentationVariant](UI.xml#L1095)|[PresentationVariantType](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
+[ID](UI.xml#L1066)|String?|Optional identifier to reference this variant from an external context
+[Text](UI.xml#L1071)|String?|Name of the bundling variant
+[SelectionVariant](UI.xml#L1075)|[SelectionVariantType](#SelectionVariantType)|Selection variant, either specified inline or referencing another annotation via Path
+[PresentationVariant](UI.xml#L1078)|[PresentationVariantType](#PresentationVariantType)|Presentation variant, either specified inline or referencing another annotation via Path
 
 <a name="PresentationVariantType"></a>
-## [PresentationVariantType](UI.xml#L1106)
+## [PresentationVariantType](UI.xml#L1089)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1107)|String?|Optional identifier to reference this variant from an external context
-[Text](UI.xml#L1110)|String?|Name of the presentation variant
-[MaxItems](UI.xml#L1114)|Int32?|Maximum number of items that should be included in the result
-[SortOrder](UI.xml#L1117)|\[[SortOrderType](Common.md#SortOrderType)\]|Collection can be provided inline or as a reference to a Common.SortOrder annotation via Path
-[GroupBy](UI.xml#L1120)|\[PropertyPath\]|Sequence of groupable properties p1, p2, ... defining how the result is composed of instances representing groups, one for each combination of value properties in the queried collection. The sequence specifies a certain level of aggregation for the queried collection, and every group instance will provide aggregated values for properties that are aggregatable. Moreover, the series of sub-sequences (p1), (p1, p2), ... forms a leveled hierarchy, which may become relevant in combination with `InitialExpansionLevel`.
-[TotalBy](UI.xml#L1129)|\[PropertyPath\]|Sub-sequence q1, q2, ... of properties p1, p2, ... specified in GroupBy. With this, additional levels of aggregation are requested in addition to the most granular level defined by GroupBy: Every element in the series of sub-sequences (q1), (q1, q2), ... introduces an additional aggregation level included in the result.
-[Total](UI.xml#L1136)|\[PropertyPath\]|Aggregatable properties for which aggregated values should be provided for the additional aggregation levels specified in TotalBy.
-[DynamicTotal](UI.xml#L1142)|\[AnnotationPath\]|Dynamic properties introduced by annotations for which aggregated values should be provided for the additional aggregation levels specified in TotalBy<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being presented according to the `UI.PresentationVariant` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[IncludeGrandTotal](UI.xml#L1155)|Boolean|Result should include a grand total for the properties specified in Total
-[InitialExpansionLevel](UI.xml#L1158)|Int32|Level up to which the hierarchy defined for the queried collection should be expanded initially. The hierarchy may be implicitly imposed by the sequence of the GroupBy, or by an explicit hierarchy annotation.
-[Visualizations](UI.xml#L1164)|\[AnnotationPath\]|Lists available visualization types. Currently supported types are `UI.LineItem`, `UI.Chart`, and `UI.DataPoint`. For each type, no more than a single annotation is meaningful. Multiple instances of the same visualization type shall be modeled with different presentation variants. A reference to `UI.Lineitem` should always be part of the collection (least common denominator for renderers). The first entry of the collection is the default visualization.<br>Allowed terms:<ul><li>[Chart](#Chart)</li><li>[DataPoint](#DataPoint)</li><li>[LineItem](#LineItem)</li></ul>
-[RecursiveHierarchyQualifier](UI.xml#L1181) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|Qualifier of the recursive hierarchy that should be applied to the Visualization<br>Variant 1 for hierarchical LineItems
-[RequestAtLeast](UI.xml#L1188)|\[PropertyPath\]|Properties that should always be included in the result of the queried collection<br>Properties in `RequestAtLeast` must occur either in the `$select` clause of an OData request or among the grouping properties in an `$apply=groupby((grouping properties),...)` clause of an aggregating OData request.
-[SelectionFields](UI.xml#L1211) *([Experimental](Common.md#Experimental))*|\[PropertyPath\]|Properties that should be presented for filtering a collection of entities. Can be provided inline or as a reference to a `UI.SelectionFields` annotation via Path.
+[ID](UI.xml#L1090)|String?|Optional identifier to reference this variant from an external context
+[Text](UI.xml#L1093)|String?|Name of the presentation variant
+[MaxItems](UI.xml#L1097)|Int32?|Maximum number of items that should be included in the result
+[SortOrder](UI.xml#L1100)|\[[SortOrderType](Common.md#SortOrderType)\]|Collection can be provided inline or as a reference to a Common.SortOrder annotation via Path
+[GroupBy](UI.xml#L1103)|\[PropertyPath\]|Sequence of groupable properties p1, p2, ... defining how the result is composed of instances representing groups, one for each combination of value properties in the queried collection. The sequence specifies a certain level of aggregation for the queried collection, and every group instance will provide aggregated values for properties that are aggregatable. Moreover, the series of sub-sequences (p1), (p1, p2), ... forms a leveled hierarchy, which may become relevant in combination with `InitialExpansionLevel`.
+[TotalBy](UI.xml#L1112)|\[PropertyPath\]|Sub-sequence q1, q2, ... of properties p1, p2, ... specified in GroupBy. With this, additional levels of aggregation are requested in addition to the most granular level defined by GroupBy: Every element in the series of sub-sequences (q1), (q1, q2), ... introduces an additional aggregation level included in the result.
+[Total](UI.xml#L1119)|\[PropertyPath\]|Aggregatable properties for which aggregated values should be provided for the additional aggregation levels specified in TotalBy.
+[DynamicTotal](UI.xml#L1125)|\[AnnotationPath\]|Dynamic properties introduced by annotations for which aggregated values should be provided for the additional aggregation levels specified in TotalBy<br>If the annotation referenced by an annotation path does not apply to the same collection of entities as the one being presented according to the `UI.PresentationVariant` annotation, the annotation path MUST be silently ignored.<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[IncludeGrandTotal](UI.xml#L1138)|Boolean|Result should include a grand total for the properties specified in Total
+[InitialExpansionLevel](UI.xml#L1141)|Int32|Level up to which the hierarchy defined for the queried collection should be expanded initially. The hierarchy may be implicitly imposed by the sequence of the GroupBy, or by an explicit hierarchy annotation.
+[Visualizations](UI.xml#L1147)|\[AnnotationPath\]|Lists available visualization types. Currently supported types are `UI.LineItem`, `UI.Chart`, and `UI.DataPoint`. For each type, no more than a single annotation is meaningful. Multiple instances of the same visualization type shall be modeled with different presentation variants. A reference to `UI.Lineitem` should always be part of the collection (least common denominator for renderers). The first entry of the collection is the default visualization.<br>Allowed terms:<ul><li>[Chart](#Chart)</li><li>[DataPoint](#DataPoint)</li><li>[LineItem](#LineItem)</li></ul>
+[RecursiveHierarchyQualifier](UI.xml#L1164) *([Experimental](Common.md#Experimental))*|[HierarchyQualifier?](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#HierarchyQualifier)|Qualifier of the recursive hierarchy that should be applied to the Visualization
+[RequestAtLeast](UI.xml#L1168)|\[PropertyPath\]|Properties that should always be included in the result of the queried collection<br>Properties in `RequestAtLeast` must occur either in the `$select` clause of an OData request or among the grouping properties in an `$apply=groupby((grouping properties),...)` clause of an aggregating OData request.
+[SelectionFields](UI.xml#L1191) *([Experimental](Common.md#Experimental))*|\[PropertyPath\]|Properties that should be presented for filtering a collection of entities. Can be provided inline or as a reference to a `UI.SelectionFields` annotation via Path.
 
 <a name="SelectionVariantType"></a>
-## [SelectionVariantType](UI.xml#L1225)
+## [SelectionVariantType](UI.xml#L1205)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[ID](UI.xml#L1226)|String?|May contain identifier to reference this instance from an external context
-[Text](UI.xml#L1231)|String?|Name of the selection variant
-[Parameters](UI.xml#L1235)|\[[ParameterAbstract](#ParameterAbstract)\]|Parameters of the selection variant
-[FilterExpression](UI.xml#L1238)|String?|Filter string for query part of URL, without `$filter=`
-[SelectOptions](UI.xml#L1243)|\[[SelectOptionType](#SelectOptionType)\]|ABAP Select Options Pattern
+[ID](UI.xml#L1206)|String?|May contain identifier to reference this instance from an external context
+[Text](UI.xml#L1211)|String?|Name of the selection variant
+[Parameters](UI.xml#L1215)|\[[ParameterAbstract](#ParameterAbstract)\]|Parameters of the selection variant
+[FilterExpression](UI.xml#L1218)|String?|Filter string for query part of URL, without `$filter=`
+[SelectOptions](UI.xml#L1223)|\[[SelectOptionType](#SelectOptionType)\]|ABAP Select Options Pattern
 
 <a name="ParameterAbstract"></a>
-## [*ParameterAbstract*](UI.xml#L1250)
+## [*ParameterAbstract*](UI.xml#L1230)
 Key property of a parameter entity type
 
 **Derived Types:**
@@ -686,128 +684,128 @@ Key property of a parameter entity type
 - [IntervalParameter](#IntervalParameter)
 
 <a name="Parameter"></a>
-## [Parameter](UI.xml#L1253): [ParameterAbstract](#ParameterAbstract)
+## [Parameter](UI.xml#L1233): [ParameterAbstract](#ParameterAbstract)
 Single-valued parameter
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyName](UI.xml#L1255)|PropertyPath|Path to a key property of a parameter entity type
-[PropertyValue](UI.xml#L1258)|PrimitiveType|Value for the key property
+[PropertyName](UI.xml#L1235)|PropertyPath|Path to a key property of a parameter entity type
+[PropertyValue](UI.xml#L1238)|PrimitiveType|Value for the key property
 
 <a name="IntervalParameter"></a>
-## [IntervalParameter](UI.xml#L1262): [ParameterAbstract](#ParameterAbstract)
+## [IntervalParameter](UI.xml#L1242): [ParameterAbstract](#ParameterAbstract)
 Interval parameter formed with a 'from' and a 'to' property
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyNameFrom](UI.xml#L1264)|PropertyPath|Path to the 'from' property of a parameter entity type
-[PropertyValueFrom](UI.xml#L1267)|PrimitiveType|Value for the 'from' property
-[PropertyNameTo](UI.xml#L1270)|PropertyPath|Path to the 'to' property of a parameter entity type
-[PropertyValueTo](UI.xml#L1273)|PrimitiveType|Value for the 'to' property
+[PropertyNameFrom](UI.xml#L1244)|PropertyPath|Path to the 'from' property of a parameter entity type
+[PropertyValueFrom](UI.xml#L1247)|PrimitiveType|Value for the 'from' property
+[PropertyNameTo](UI.xml#L1250)|PropertyPath|Path to the 'to' property of a parameter entity type
+[PropertyValueTo](UI.xml#L1253)|PrimitiveType|Value for the 'to' property
 
 <a name="SelectOptionType"></a>
-## [SelectOptionType](UI.xml#L1278)
+## [SelectOptionType](UI.xml#L1258)
 List of value ranges for a single property
 
 Exactly one of `PropertyName` and `DynamicPropertyName` must be present
 
 Property|Type|Description
 :-------|:---|:----------
-[PropertyName](UI.xml#L1281)|PropertyPath?|Path to the property
-[DynamicPropertyName](UI.xml#L1293)|AnnotationPath?|Dynamic property introduced by annotations for which value ranges are specified<br>If the annotation referenced by the annotation path does not apply to the same collection of entities as the one being filtered according to the `UI.SelectionVariant` annotation, this instance of `UI.SelectionVariant/SelectOptions` MUST be silently ignored. For an example, see the `UI.SelectionVariant` annotation in the [example](../examples/DynamicProperties-sample.xml).<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
-[Ranges](UI.xml#L1307)|\[[SelectionRangeType](#SelectionRangeType)\]|List of value ranges
+[PropertyName](UI.xml#L1261)|PropertyPath?|Path to the property
+[DynamicPropertyName](UI.xml#L1273)|AnnotationPath?|Dynamic property introduced by annotations for which value ranges are specified<br>If the annotation referenced by the annotation path does not apply to the same collection of entities as the one being filtered according to the `UI.SelectionVariant` annotation, this instance of `UI.SelectionVariant/SelectOptions` MUST be silently ignored. For an example, see the `UI.SelectionVariant` annotation in the [example](../examples/DynamicProperties-sample.xml).<br>Allowed terms:<ul><li>[AggregatedProperty](Analytics.md#AggregatedProperty)</li><li>[CustomAggregate](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Aggregation.V1.md#CustomAggregate)</li></ul>
+[Ranges](UI.xml#L1287)|\[[SelectionRangeType](#SelectionRangeType)\]|List of value ranges
 
 <a name="SelectionRangeType"></a>
-## [SelectionRangeType](UI.xml#L1312)
+## [SelectionRangeType](UI.xml#L1292)
 Value range. If the range option only requires a single value, the value must be in the property Low
 
 Property|Type|Description
 :-------|:---|:----------
-[Sign](UI.xml#L1316)|[SelectionRangeSignType](#SelectionRangeSignType)|Include or exclude values
-[Option](UI.xml#L1319)|[SelectionRangeOptionType](#SelectionRangeOptionType)|Comparison operator
-[Low](UI.xml#L1322)|PrimitiveType|Single value or lower interval boundary
-[High](UI.xml#L1325)|PrimitiveType?|Upper interval boundary
+[Sign](UI.xml#L1296)|[SelectionRangeSignType](#SelectionRangeSignType)|Include or exclude values
+[Option](UI.xml#L1299)|[SelectionRangeOptionType](#SelectionRangeOptionType)|Comparison operator
+[Low](UI.xml#L1302)|PrimitiveType|Single value or lower interval boundary
+[High](UI.xml#L1305)|PrimitiveType?|Upper interval boundary
 
 <a name="SelectionRangeSignType"></a>
-## [SelectionRangeSignType](UI.xml#L1330)
+## [SelectionRangeSignType](UI.xml#L1310)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[I](UI.xml#L1331)|0|Inclusive
-[E](UI.xml#L1334)|1|Exclusive
+[I](UI.xml#L1311)|0|Inclusive
+[E](UI.xml#L1314)|1|Exclusive
 
 <a name="SelectionRangeOptionType"></a>
-## [SelectionRangeOptionType](UI.xml#L1339)
+## [SelectionRangeOptionType](UI.xml#L1319)
 Comparison operator
 
 Member|Value|Description
 :-----|----:|:----------
-[EQ](UI.xml#L1341)|0|Equal to
-[BT](UI.xml#L1344)|1|Between
-[CP](UI.xml#L1347)|2|Contains pattern
-[LE](UI.xml#L1350)|3|Less than or equal to
-[GE](UI.xml#L1353)|4|Greater than or equal to
-[NE](UI.xml#L1356)|5|Not equal to
-[NB](UI.xml#L1359)|6|Not between
-[NP](UI.xml#L1362)|7|Does not contain pattern
-[GT](UI.xml#L1365)|8|Greater than
-[LT](UI.xml#L1368)|9|Less than
+[EQ](UI.xml#L1321)|0|Equal to
+[BT](UI.xml#L1324)|1|Between
+[CP](UI.xml#L1327)|2|Contains pattern
+[LE](UI.xml#L1330)|3|Less than or equal to
+[GE](UI.xml#L1333)|4|Greater than or equal to
+[NE](UI.xml#L1336)|5|Not equal to
+[NB](UI.xml#L1339)|6|Not between
+[NP](UI.xml#L1342)|7|Does not contain pattern
+[GT](UI.xml#L1345)|8|Greater than
+[LT](UI.xml#L1348)|9|Less than
 
 <a name="InputMaskType"></a>
-## [InputMaskType](UI.xml#L1436) *([Experimental](Common.md#Experimental))*
+## [InputMaskType](UI.xml#L1416) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Mask](UI.xml#L1438)|String|The mask to be applied to the property or the parameter
-[PlaceholderSymbol](UI.xml#L1441)|String|A single character symbol to be shown where the user can type a character
-[Rules](UI.xml#L1444)|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
+[Mask](UI.xml#L1418)|String|The mask to be applied to the property or the parameter
+[PlaceholderSymbol](UI.xml#L1421)|String|A single character symbol to be shown where the user can type a character
+[Rules](UI.xml#L1424)|\[[InputMaskRuleType](#InputMaskRuleType)\]|Rules that define valid values for one symbol in the mask<br>The following rules are defined as default and don't need to be listed here: * = ., C = [a-zA-Z], 9 = [0-9]
 
 <a name="InputMaskRuleType"></a>
-## [InputMaskRuleType](UI.xml#L1451) *([Experimental](Common.md#Experimental))*
+## [InputMaskRuleType](UI.xml#L1431) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[MaskSymbol](UI.xml#L1453)|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
-[RegExp](UI.xml#L1456)|String|Regular expression that defines the valid values for the mask symbol
+[MaskSymbol](UI.xml#L1433)|String|A symbol in the mask that stands for a regular expression which must be matched by the user input in every position where this symbol occurs
+[RegExp](UI.xml#L1436)|String|Regular expression that defines the valid values for the mask symbol
 
 <a name="TextArrangementType"></a>
-## [TextArrangementType](UI.xml#L1469)
+## [TextArrangementType](UI.xml#L1449)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[TextFirst](UI.xml#L1470)|0|Text is first, followed by the code/ID (e.g. in parentheses)
-[TextLast](UI.xml#L1473)|1|Code/ID is first, followed by the text (e.g. separated by a dash)
-[TextSeparate](UI.xml#L1476)|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
-[TextOnly](UI.xml#L1479)|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
+[TextFirst](UI.xml#L1450)|0|Text is first, followed by the code/ID (e.g. in parentheses)
+[TextLast](UI.xml#L1453)|1|Code/ID is first, followed by the text (e.g. separated by a dash)
+[TextSeparate](UI.xml#L1456)|2|Code/ID and text are represented separately (code/ID will be shown and text can be visualized in a separate place)
+[TextOnly](UI.xml#L1459)|3|Only text is represented, code/ID is hidden (e.g. for UUIDs)
 
 <a name="NoteType"></a>
-## [NoteType](UI.xml#L1496) *([Experimental](Common.md#Experimental))*
+## [NoteType](UI.xml#L1476) *([Experimental](Common.md#Experimental))*
 
 
 Property|Type|Description
 :-------|:---|:----------
-[Title](UI.xml#L1498)|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
-[Content](UI.xml#L1510)|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
-[Type](UI.xml#L1526)|String|A type used for grouping notes
-[MaximalLength](UI.xml#L1529)|Int32?|Type-specific maximal length of the content of the note
-[MultipleNotes](UI.xml#L1532)|Boolean|Whether the type allows multiple notes for one object
+[Title](UI.xml#L1478)|String?|Title of the note<br>The title of a note is hidden with an annotation `@UI.Note/Title/@UI.Hidden`, not with an annotation on the property targeted by `@UI.Note/Title`.<br>Can be annotated with:<ul><li>[Hidden](#Hidden)</li></ul>
+[Content](UI.xml#L1490)|String|Content of the note, as a string<br>The property targeted by `@UI.Note/Content` must be annotated with `Core.MediaType` and may be annotated with `Common.SAPObjectNodeTypeReference`. When it is tagged with `Core.IsLanguageDependent`, another property of the same entity type that is tagged with [`Common.IsLanguageIdentifier`](Common.md#IsLanguageIdentifier) determines the language of the note.<br>Can be annotated with:<ul><li>[MediaType](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#MediaType)</li><li>[IsLanguageDependent](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#IsLanguageDependent)</li><li>[SAPObjectNodeTypeReference](Common.md#SAPObjectNodeTypeReference)</li></ul>
+[Type](UI.xml#L1506)|String|A type used for grouping notes
+[MaximalLength](UI.xml#L1509)|Int32?|Type-specific maximal length of the content of the note
+[MultipleNotes](UI.xml#L1512)|Boolean|Whether the type allows multiple notes for one object
 
 <a name="ImportanceType"></a>
-## [ImportanceType](UI.xml#L1540)
+## [ImportanceType](UI.xml#L1520)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[High](UI.xml#L1541)|0|High importance
-[Medium](UI.xml#L1544)|1|Medium importance
-[Low](UI.xml#L1547)|2|Low importance
+[High](UI.xml#L1521)|0|High importance
+[Medium](UI.xml#L1524)|1|Medium importance
+[Low](UI.xml#L1527)|2|Low importance
 
 <a name="DataFieldAbstract"></a>
-## [*DataFieldAbstract*](UI.xml#L1607)
+## [*DataFieldAbstract*](UI.xml#L1587)
 Elementary building block that represents a piece of data and/or allows triggering an action
 
 By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the visibility, the importance and
@@ -828,10 +826,10 @@ By using the applicable terms UI.Hidden, UI.Importance or HTML5.CssDefaults, the
 
 Property|Type|Description
 :-------|:---|:----------
-[Label](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[Criticality](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[CriticalityRepresentation](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[IconUrl](UI.xml#L1633)|URL?|Optional icon
+[Label](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[Criticality](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[CriticalityRepresentation](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[IconUrl](UI.xml#L1613)|URL?|Optional icon
 
 **Applicable Annotation Terms:**
 
@@ -843,26 +841,26 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="CriticalityRepresentationType"></a>
-## [CriticalityRepresentationType](UI.xml#L1639)
+## [CriticalityRepresentationType](UI.xml#L1619)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[WithIcon](UI.xml#L1640)|0|Criticality is represented with an icon
-[WithoutIcon](UI.xml#L1643)|1|Criticality is represented without icon, e.g. only via text color
-[OnlyIcon](UI.xml#L1646) *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
+[WithIcon](UI.xml#L1620)|0|Criticality is represented with an icon
+[WithoutIcon](UI.xml#L1623)|1|Criticality is represented without icon, e.g. only via text color
+[OnlyIcon](UI.xml#L1626) *([Experimental](Common.md#Experimental))*|2|Criticality is represented only by using an icon
 
 <a name="DataFieldForAnnotation"></a>
-## [DataFieldForAnnotation](UI.xml#L1652): [DataFieldAbstract](#DataFieldAbstract)
+## [DataFieldForAnnotation](UI.xml#L1632): [DataFieldAbstract](#DataFieldAbstract)
 A structured piece of data described by an annotation
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Target](UI.xml#L1654)|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Target](UI.xml#L1634)|AnnotationPath|Target MUST reference an annotation of terms Communication.Contact, Communication.Address, UI.DataPoint, UI.Chart, UI.FieldGroup, or UI.ConnectedFields<br>Allowed terms:<ul><li>[Address](Communication.md#Address)</li><li>[Contact](Communication.md#Contact)</li><li>[Chart](#Chart)</li><li>[ConnectedFields](#ConnectedFields)</li><li>[DataPoint](#DataPoint)</li><li>[FieldGroup](#FieldGroup)</li></ul>
 
 **Applicable Annotation Terms:**
 
@@ -874,7 +872,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionAbstract"></a>
-## [*DataFieldForActionAbstract*](UI.xml#L1669): [DataFieldAbstract](#DataFieldAbstract)
+## [*DataFieldForActionAbstract*](UI.xml#L1649): [DataFieldAbstract](#DataFieldAbstract)
 Triggers an action
 
 **Derived Types:**
@@ -883,12 +881,12 @@ Triggers an action
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Inline](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
-[Determining](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Inline](UI.xml#L1651)|Boolean|Action should be placed close to (or even inside) the visualized term
+[Determining](UI.xml#L1654)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
 
 **Applicable Annotation Terms:**
 
@@ -900,21 +898,21 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForAction"></a>
-## [DataFieldForAction](UI.xml#L1679): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForAction](UI.xml#L1659): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers an OData action
 
 The action is NOT tied to a data value (in contrast to [DataFieldWithAction](#DataFieldWithAction)).
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[*Inline*](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[Action](UI.xml#L1682)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
-[InvocationGrouping](UI.xml#L1685)|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[*Inline*](UI.xml#L1651)|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](UI.xml#L1654)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[Action](UI.xml#L1662)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[InvocationGrouping](UI.xml#L1665)|[OperationGroupingType?](#OperationGroupingType)|Expresses how invocations of this action on multiple instances should be grouped
 
 **Applicable Annotation Terms:**
 
@@ -926,16 +924,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="OperationGroupingType"></a>
-## [OperationGroupingType](UI.xml#L1689)
+## [OperationGroupingType](UI.xml#L1669)
 
 
 Member|Value|Description
 :-----|----:|:----------
-[Isolated](UI.xml#L1690)|0|Invoke each action in isolation from other actions
-[ChangeSet](UI.xml#L1693)|1|Group all actions into a single change set
+[Isolated](UI.xml#L1670)|0|Invoke each action in isolation from other actions
+[ChangeSet](UI.xml#L1673)|1|Group all actions into a single change set
 
 <a name="DataFieldForIntentBasedNavigation"></a>
-## [DataFieldForIntentBasedNavigation](UI.xml#L1698): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
+## [DataFieldForIntentBasedNavigation](UI.xml#L1678): [DataFieldForActionAbstract](#DataFieldForActionAbstract)
 Triggers intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -944,17 +942,17 @@ It is NOT tied to a data value (in contrast to [DataFieldWithIntentBasedNavigati
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[*Inline*](UI.xml#L1671)|Boolean|Action should be placed close to (or even inside) the visualized term
-[*Determining*](UI.xml#L1674)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
-[SemanticObject](UI.xml#L1705)|String|Name of the Semantic Object
-[Action](UI.xml#L1708)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[NavigationAvailable](UI.xml#L1711)|Boolean|The navigation intent is for that user with the selected context and parameters available
-[RequiresContext](UI.xml#L1714)|Boolean|Determines whether a context needs to be passed to the target of this navigation.
-[Mapping](UI.xml#L1717)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[*Inline*](UI.xml#L1651)|Boolean|Action should be placed close to (or even inside) the visualized term
+[*Determining*](UI.xml#L1654)|Boolean|Determines whether the action completes a process step (e.g. approve, reject).
+[SemanticObject](UI.xml#L1685)|String|Name of the Semantic Object
+[Action](UI.xml#L1688)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[NavigationAvailable](UI.xml#L1691)|Boolean|The navigation intent is for that user with the selected context and parameters available
+[RequiresContext](UI.xml#L1694)|Boolean|Determines whether a context needs to be passed to the target of this navigation.
+[Mapping](UI.xml#L1697)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -966,16 +964,16 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldForActionGroup"></a>
-## [DataFieldForActionGroup](UI.xml#L1722): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
+## [DataFieldForActionGroup](UI.xml#L1702): [DataFieldAbstract](#DataFieldAbstract) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Actions](UI.xml#L1725)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Actions](UI.xml#L1705)|\[[DataFieldForActionAbstract](#DataFieldForActionAbstract)\]|Collection of data fields that refer to actions or intent based navigations
 
 **Applicable Annotation Terms:**
 
@@ -987,7 +985,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataField"></a>
-## [DataField](UI.xml#L1730): [DataFieldAbstract](#DataFieldAbstract)
+## [DataField](UI.xml#L1710): [DataFieldAbstract](#DataFieldAbstract)
 A piece of data
 
 **Derived Types:**
@@ -999,11 +997,11 @@ A piece of data
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1732)|Untyped|The data field's value
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1712)|Untyped|The data field's value
 
 **Applicable Annotation Terms:**
 
@@ -1015,19 +1013,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithAction"></a>
-## [DataFieldWithAction](UI.xml#L1759): [DataField](#DataField)
+## [DataFieldWithAction](UI.xml#L1739): [DataField](#DataField)
 A piece of data that allows triggering an OData action
 
 The action is tied to a data value. This is in contrast to [DataFieldForAction](#DataFieldForAction) which is not tied to a specific data value.
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1762)|PrimitiveType|The data field's value
-[Action](UI.xml#L1763)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1742)|PrimitiveType|The data field's value
+[Action](UI.xml#L1743)|[ActionName](#ActionName)|Name of an Action, Function, ActionImport, or FunctionImport in scope
 
 **Applicable Annotation Terms:**
 
@@ -1039,7 +1037,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithIntentBasedNavigation"></a>
-## [DataFieldWithIntentBasedNavigation](UI.xml#L1768): [DataField](#DataField)
+## [DataFieldWithIntentBasedNavigation](UI.xml#L1748): [DataField](#DataField)
 A piece of data that allows triggering intent-based UI navigation
 
 The navigation intent is expressed as a Semantic Object and optionally an Action on that object.
@@ -1049,14 +1047,14 @@ This is in contrast to [DataFieldForIntentBasedNavigation](#DataFieldForIntentBa
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1776)|PrimitiveType|The data field's value
-[SemanticObject](UI.xml#L1777)|String|Name of the Semantic Object
-[Action](UI.xml#L1780)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
-[Mapping](UI.xml#L1783)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1756)|PrimitiveType|The data field's value
+[SemanticObject](UI.xml#L1757)|String|Name of the Semantic Object
+[Action](UI.xml#L1760)|String?|Name of the Action on the Semantic Object. If not specified, let user choose which of the available actions to trigger.
+[Mapping](UI.xml#L1763)|\[[SemanticObjectMappingType](Common.md#SemanticObjectMappingType)\]|Maps properties of the annotated entity type to properties of the Semantic Object
 
 **Applicable Annotation Terms:**
 
@@ -1068,19 +1066,19 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithNavigationPath"></a>
-## [DataFieldWithNavigationPath](UI.xml#L1788): [DataField](#DataField)
+## [DataFieldWithNavigationPath](UI.xml#L1768): [DataField](#DataField)
 A piece of data that allows navigating to related data
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1791)|PrimitiveType|The data field's value
-[Target](UI.xml#L1792)|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1771)|PrimitiveType|The data field's value
+[Target](UI.xml#L1772)|NavigationPropertyPath|Contains either a navigation property or a term cast, where term is of type Edm.EntityType or a concrete entity type or a collection of these types
 
 **Applicable Annotation Terms:**
 
@@ -1092,20 +1090,20 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithUrl"></a>
-## [DataFieldWithUrl](UI.xml#L1799): [DataField](#DataField)
+## [DataFieldWithUrl](UI.xml#L1779): [DataField](#DataField)
 A piece of data that allows navigating to other information on the Web
 
 It should be rendered as a hyperlink
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1802)|PrimitiveType|The data field's value
-[Url](UI.xml#L1803)|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
-[UrlContentType](UI.xml#L1812)|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1782)|PrimitiveType|The data field's value
+[Url](UI.xml#L1783)|URL|Target of the hyperlink<br>Can be annotated with:<ul><li>[LinkTarget](HTML5.md#LinkTarget)</li></ul>
+[UrlContentType](UI.xml#L1792)|MediaType?|Media type of the hyperlink target, e.g. `video/mp4`
 
 **Applicable Annotation Terms:**
 
@@ -1117,17 +1115,17 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="DataFieldWithActionGroup"></a>
-## [DataFieldWithActionGroup](UI.xml#L1818): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
+## [DataFieldWithActionGroup](UI.xml#L1798): [DataField](#DataField) *([Experimental](Common.md#Experimental))*
 Collection of OData actions and intent based navigations
 
 Property|Type|Description
 :-------|:---|:----------
-[*Label*](UI.xml#L1623)|String?|A short, human-readable text suitable for labels and captions in UIs
-[*Criticality*](UI.xml#L1627)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
-[*CriticalityRepresentation*](UI.xml#L1630)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
-[*IconUrl*](UI.xml#L1633)|URL?|Optional icon
-[Value](UI.xml#L1821)|PrimitiveType|The data field's value
-[Actions](UI.xml#L1822)|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
+[*Label*](UI.xml#L1603)|String?|A short, human-readable text suitable for labels and captions in UIs
+[*Criticality*](UI.xml#L1607)|[CriticalityType?](#CriticalityType)|Criticality of the data field value
+[*CriticalityRepresentation*](UI.xml#L1610)|[CriticalityRepresentationType?](#CriticalityRepresentationType)|Decides if criticality is visualized in addition by means of an icon
+[*IconUrl*](UI.xml#L1613)|URL?|Optional icon
+[Value](UI.xml#L1801)|PrimitiveType|The data field's value
+[Actions](UI.xml#L1802)|\[[DataField](#DataField)\]|Collection of data fields that are either [DataFieldWithAction](#DataFieldWithAction), [DataFieldWithIntentBasedNavigation](#DataFieldWithIntentBasedNavigation), [DataFieldWithNavigationPath](#DataFieldWithNavigationPath), or [DataFieldWithUrl](#DataFieldWithUrl)
 
 **Applicable Annotation Terms:**
 
@@ -1139,7 +1137,7 @@ Property|Type|Description
 - [FieldControl](Common.md#FieldControl)
 
 <a name="RecommendationStateType"></a>
-## [RecommendationStateType](UI.xml#L1860)
+## [RecommendationStateType](UI.xml#L1840)
 **Type:** Byte
 
 Indicates whether a field contains or has a recommended value
@@ -1148,33 +1146,33 @@ Editable fields for which a recommendation has been pre-filled or that have reco
 
 Allowed Value|Description
 :------------|:----------
-[0](UI.xml#L1867)|regular - with human or default input, no recommendation
-[1](UI.xml#L1871)|highlighted - without human input and with recommendation
-[2](UI.xml#L1875)|warning - with human or default input and with recommendation
+[0](UI.xml#L1847)|regular - with human or default input, no recommendation
+[1](UI.xml#L1851)|highlighted - without human input and with recommendation
+[2](UI.xml#L1855)|warning - with human or default input and with recommendation
 
 <a name="RecommendationListType"></a>
-## [RecommendationListType](UI.xml#L1890)
+## [RecommendationListType](UI.xml#L1870)
 Reference to a recommendation list
 
 A recommendation consists of one or more values for editable fields plus a rank between 0.0 and 9.9, with 9.9 being the best recommendation.
 
 Property|Type|Description
 :-------|:---|:----------
-[CollectionPath](UI.xml#L1895)|String|Resource path of a collection of recommended values
-[RankProperty](UI.xml#L1898)|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
-[Binding](UI.xml#L1901)|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
+[CollectionPath](UI.xml#L1875)|String|Resource path of a collection of recommended values
+[RankProperty](UI.xml#L1878)|String|Name of the property within the collection of recommended values that describes the rank of the recommendation
+[Binding](UI.xml#L1881)|\[[RecommendationBinding](#RecommendationBinding)\]|List of pairs of a local property and recommended value property
 
 <a name="RecommendationBinding"></a>
-## [RecommendationBinding](UI.xml#L1906)
+## [RecommendationBinding](UI.xml#L1886)
 
 
 Property|Type|Description
 :-------|:---|:----------
-[LocalDataProperty](UI.xml#L1907)|PropertyPath|Path to editable property for which recommended values exist
-[ValueListProperty](UI.xml#L1910)|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
+[LocalDataProperty](UI.xml#L1887)|PropertyPath|Path to editable property for which recommended values exist
+[ValueListProperty](UI.xml#L1890)|String|Path to property in the collection of recommended values. Format is identical to PropertyPath annotations.
 
 <a name="ActionName"></a>
-## [ActionName](UI.xml#L1934)
+## [ActionName](UI.xml#L1914)
 **Type:** String
 
 Name of an Action, Function, ActionImport, or FunctionImport in scope

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -149,6 +149,23 @@ a collection of business object instances, e.g. as a list or table.</String>
         <Annotation Term="UI.ThingPerspective" />
       </Term>
 
+      <Term Name="ApplyRecursiveHierarchy" Type="Aggregation.HierarchyQualifier" AppliesTo="Annotation">
+        <Annotation Term="Common.Experimental" />       
+        <Annotation Term="Core.RequiresType" String="UI.LineItem"/>
+        <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to a UI.LineItem" />
+        <Annotation Term="Core.LongDescription">
+          <String>Variant 2 for hierarchical LineItems</String>
+        </Annotation>
+      </Term>
+
+      <Term Name="HierarchicalLineItem" BaseTerm="UI.LineItem" Type="Aggregation.HierarchyQualifier" AppliesTo="EntityType">
+        <Annotation Term="Common.Experimental" />
+        <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier" />
+        <Annotation Term="Core.LongDescription">
+          <String>Variant 3 for hierarchical LineItems</String>
+        </Annotation>
+      </Term>
+
       <Term Name="StatusInfo" Type="Collection(UI.DataFieldAbstract)" Nullable="false" AppliesTo="EntityType">
         <Annotation Term="Core.Description" String="Collection of data fields describing the status of an entity" />
         <Annotation Term="UI.ThingPerspective" />
@@ -965,7 +982,6 @@ The trend is
         <Annotation Term="Core.Description" String="Properties that might be relevant for filtering a collection of entities of this type" />
       </Term>
 
-
       <!-- Segmentation of content according to facets of the Object -->
 
       <Term Name="Facets" Type="Collection(UI.Facet)" Nullable="false" AppliesTo="EntityType">
@@ -1160,6 +1176,13 @@ The trend is
               <String>UI.DataPoint</String>
               <String>UI.LineItem</String>
             </Collection>
+          </Annotation>
+        </Property>
+        <Property Name="RecursiveHierarchyQualifier" Type="Aggregation.HierarchyQualifier">
+          <Annotation Term="Common.Experimental" />
+          <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to the Visualization" />
+          <Annotation Term="Core.LongDescription">
+            <String>Variant 1 for hierarchical LineItems</String>
           </Annotation>
         </Property>
         <Property Name="RequestAtLeast" Type="Collection(Edm.PropertyPath)" Nullable="false">

--- a/vocabularies/UI.xml
+++ b/vocabularies/UI.xml
@@ -149,23 +149,6 @@ a collection of business object instances, e.g. as a list or table.</String>
         <Annotation Term="UI.ThingPerspective" />
       </Term>
 
-      <Term Name="ApplyRecursiveHierarchy" Type="Aggregation.HierarchyQualifier" AppliesTo="Annotation">
-        <Annotation Term="Common.Experimental" />       
-        <Annotation Term="Core.RequiresType" String="UI.LineItem"/>
-        <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to a UI.LineItem" />
-        <Annotation Term="Core.LongDescription">
-          <String>Variant 2 for hierarchical LineItems</String>
-        </Annotation>
-      </Term>
-
-      <Term Name="HierarchicalLineItem" BaseTerm="UI.LineItem" Type="Aggregation.HierarchyQualifier" AppliesTo="EntityType">
-        <Annotation Term="Common.Experimental" />
-        <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to the UI.LineItem having the same qualifier" />
-        <Annotation Term="Core.LongDescription">
-          <String>Variant 3 for hierarchical LineItems</String>
-        </Annotation>
-      </Term>
-
       <Term Name="StatusInfo" Type="Collection(UI.DataFieldAbstract)" Nullable="false" AppliesTo="EntityType">
         <Annotation Term="Core.Description" String="Collection of data fields describing the status of an entity" />
         <Annotation Term="UI.ThingPerspective" />
@@ -1181,9 +1164,6 @@ The trend is
         <Property Name="RecursiveHierarchyQualifier" Type="Aggregation.HierarchyQualifier">
           <Annotation Term="Common.Experimental" />
           <Annotation Term="Core.Description" String="Qualifier of the recursive hierarchy that should be applied to the Visualization" />
-          <Annotation Term="Core.LongDescription">
-            <String>Variant 1 for hierarchical LineItems</String>
-          </Annotation>
         </Property>
         <Property Name="RequestAtLeast" Type="Collection(Edm.PropertyPath)" Nullable="false">
           <Annotation Term="Core.Description" String="Properties that should always be included in the result of the queried collection" />


### PR DESCRIPTION
This is PR is about the possibility to apply a hierarchy (and later one aggregation ) on existing list definition (aka UI.LineItem). We start with three different proposals: adding a new property to UI.PresentationVariant, adding a new term that can be applied on UI.LineItem annotations, adding a new term that uses UI.LineItem as BaseTerm.
