### PR TITLE
Add term "Meta"

### DIFF
--- a/vocabularies/Common.json
+++ b/vocabularies/Common.json
@@ -1327,7 +1327,7 @@
     "MetaType": {
       "$Kind": "ComplexType",
       "@Common.Experimental": true,
-      "Creator": { "@Core.Description": "Constant and version independent identification of the schema creator" }
+      "Creator": { "@Core.Description": "Constant and version-independent identification of the schema creator" }
     }
   }
 }

--- a/vocabularies/Common.json
+++ b/vocabularies/Common.json
@@ -1316,6 +1316,18 @@
       "@Common.Experimental": true,
       "@Core.IsURL": true,
       "@Core.Description": "Base URL for WebSocket connections"
+    },
+    "Meta": {
+      "$Kind": "Term",
+      "$Type": "Common.MetaType",
+      "$AppliesTo": ["Schema"],
+      "@Common.Experimental": true,
+      "@Core.Description": "Meta attributes of the Schema"
+    },
+    "MetaType": {
+      "$Kind": "ComplexType",
+      "@Common.Experimental": true,
+      "Creator": { "@Core.Description": "Constant and version independent identification of the schema creator" }
     }
   }
 }

--- a/vocabularies/Common.md
+++ b/vocabularies/Common.md
@@ -111,6 +111,7 @@ Term|Type|Description
 [mediaUploadLink](Common.xml#L1457) *([Experimental](Common.md#Experimental))*|URL|<a name="mediaUploadLink"></a>URL for uploading new media content to a Document Management Service<br>In contrast to the `@odata.mediaEditLink` this URL allows to upload new media content without directly changing a stream property or media resource. The upload request typically uses HTTP POST with `Content-Type: multipart/form-data` following RFC 7578. The upload request must contain one multipart representing the content of the file. The `name` parameter in the `Content-Disposition` header (as described in RFC 7578) is irrelevant, but the `filename` parameter is expected. If the request succeeds the response will contain a JSON body of `Content-Type: application/json` with a JSON property `readLink`. The newly uploaded media resource can be linked to the stream property by changing the `@odata.mediaReadLink` to the value of this `readLink` in a subsequent PATCH request to the OData entity.
 [PrimitivePropertyPath](Common.xml#L1472) *([Experimental](Common.md#Experimental))*|[Tag](https://github.com/oasis-tcs/odata-vocabularies/blob/main/vocabularies/Org.OData.Core.V1.md#Tag)|<a name="PrimitivePropertyPath"></a>A term or term property with this tag whose type is (a collection of) `Edm.PropertyPath` MUST resolve to a primitive structural property
 [WebSocketBaseURL](Common.xml#L1477) *([Experimental](Common.md#Experimental))*|URL|<a name="WebSocketBaseURL"></a>Base URL for WebSocket connections
+[Meta](Common.xml#L1483) *([Experimental](Common.md#Experimental))*|[MetaType](#MetaType)|<a name="Meta"></a>Meta attributes of the Schema
 
 <a name="TextFormatType"></a>
 ## [TextFormatType](Common.xml#L120)
@@ -441,3 +442,11 @@ Use terms [Aggregation.RecursiveHierarchy](https://github.com/oasis-tcs/odata-vo
 **Type:** String
 
 User ID
+
+<a name="MetaType"></a>
+## [MetaType](Common.xml#L1487) *([Experimental](Common.md#Experimental))*
+
+
+Property|Type|Description
+:-------|:---|:----------
+[Creator](Common.xml#L1489)|String|Constant and version independent identification of the schema creator

--- a/vocabularies/Common.md
+++ b/vocabularies/Common.md
@@ -449,4 +449,4 @@ User ID
 
 Property|Type|Description
 :-------|:---|:----------
-[Creator](Common.xml#L1489)|String|Constant and version independent identification of the schema creator
+[Creator](Common.xml#L1489)|String|Constant and version-independent identification of the schema creator

--- a/vocabularies/Common.xml
+++ b/vocabularies/Common.xml
@@ -1480,6 +1480,15 @@ If the request succeeds the response will contain a JSON body of `Content-Type: 
         <Annotation Term="Core.Description" String="Base URL for WebSocket connections" />
       </Term>
 
+      <Term Name="Meta" Type="Common.MetaType" Nullable="false" AppliesTo="Schema">
+        <Annotation Term="Core.Description" String="Meta attributes of the Schema" />
+      </Term>
+      <ComplexType Name="MetaType">
+        <Property Name="Creator" Type="Edm.String" Nullable="false">
+          <Annotation Term="Core.Description" String="Constant and version independent identification of the schema creator" />
+        </Property>
+      </ComplexType>
+
     </Schema>
   </edmx:DataServices>
 </edmx:Edmx>

--- a/vocabularies/Common.xml
+++ b/vocabularies/Common.xml
@@ -1481,9 +1481,11 @@ If the request succeeds the response will contain a JSON body of `Content-Type: 
       </Term>
 
       <Term Name="Meta" Type="Common.MetaType" Nullable="false" AppliesTo="Schema">
+        <Annotation Term="Common.Experimental" />
         <Annotation Term="Core.Description" String="Meta attributes of the Schema" />
       </Term>
       <ComplexType Name="MetaType">
+        <Annotation Term="Common.Experimental" />
         <Property Name="Creator" Type="Edm.String" Nullable="false">
           <Annotation Term="Core.Description" String="Constant and version independent identification of the schema creator" />
         </Property>

--- a/vocabularies/Common.xml
+++ b/vocabularies/Common.xml
@@ -1487,7 +1487,7 @@ If the request succeeds the response will contain a JSON body of `Content-Type: 
       <ComplexType Name="MetaType">
         <Annotation Term="Common.Experimental" />
         <Property Name="Creator" Type="Edm.String" Nullable="false">
-          <Annotation Term="Core.Description" String="Constant and version independent identification of the schema creator" />
+          <Annotation Term="Core.Description" String="Constant and version-independent identification of the schema creator" />
         </Property>
       </ComplexType>
 


### PR DESCRIPTION
Common.Meta shall collect "meta" information about a schema such as a creator identification string, the version number of the creator or a copy right notice.