### PR TITLE
`on: pull_request` fails on forks

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,10 +1,6 @@
 name: Rebuild JSON and MarkDown files
 
-on:
-  push:
-    branches:
-      - main
-  pull_request:
+on: push
 
 jobs:
   build:


### PR DESCRIPTION
After the recent security hardening (#430), https://github.com/SAP/odata-vocabularies/actions/runs/27005115497 ran `on: pull_request` and failed because
```
git fetch origin +refs/heads/add-ai-hint-vocabulary*:refs/remotes/origin/add-ai-hint-vocabulary*
```
mentions a branch from a forked repository, which it could not find and exited with return code 1.

By contrast, https://github.com/SAP/odata-vocabularies/actions/runs/24407834974 ran `on: push` and succeeded because
```
git fetch origin +0f5ba008653381dd1c97f2c9c3d7f4b0ea630b29:refs/remotes/origin/main
```
mentions a commit from a forked repository, which it finds.

To enable pull requests from forked repositories, we switch back to `on: push`.