### PR TITLE
How can the required build workflow be triggered on a forked repository?

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Rebuild JSON and MarkDown files
 
-on: push
+on: [push, workflow_dispatch]
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Rebuild JSON and MarkDown files
 
-on: [push, workflow_dispatch]
+on: push # What about forked repos?
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,10 @@
 name: Rebuild JSON and MarkDown files
 
-on: [push, pull_request] # What about forked repos?
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,6 +1,6 @@
 name: Rebuild JSON and MarkDown files
 
-on: push # What about forked repos?
+on: [push, pull_request] # What about forked repos?
 
 jobs:
   build:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,6 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - run: echo ${{ github.ref }}
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,10 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: echo ${{ github }}
       - uses: actions/checkout@v6
-        with:
-          ref: ${{ github.head_ref }}
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v6
         with:

--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - run: echo ${{ github.ref }}
+      - run: echo ${{ github }}
       - uses: actions/checkout@v6
         with:
           ref: ${{ github.head_ref }}


### PR DESCRIPTION
When the build workflow runs `on: pull_request` from a forked repository, it does not work as expected because of the way https://github.com/actions/checkout works in the steps "Initializing the repository" and "Fetching the repository".

In [this example](https://github.com/SAP/odata-vocabularies/actions/runs/27188982436/job/80264357150), the branch name in the forked repository is `main` and the workflow executes
```
git remote add origin https://github.com/SAP/odata-vocabularies
git fetch origin +refs/heads/main*:refs/remotes/origin/main*
```
so that the build runs on the [base branch](https://github.com/SAP/odata-vocabularies/tree/main) of the pull request. But this is meaningless because it should run on the [head branch](https://github.com/HeikoTheissen/odata-vocabularies/tree/main).

In [this example](https://github.com/SAP/odata-vocabularies/actions/runs/27005115497/job/80123801068), the branch name in the forked repository is not `main` and the workflow executes
```
git remote add origin https://github.com/SAP/odata-vocabularies
git fetch origin +refs/heads/add-ai-hint-vocabulary*:refs/remotes/origin/add-ai-hint-vocabulary*
```
Since the [fetched branch](https://github.com/vyshnavigadamsetti/odata-vocabularies/tree/add-ai-hint-vocabulary) does not exist in the non-forked `origin` repository, this fails.

The `push` event is not triggered at all when the push happens in a forked repository.

What other alternatives do we have?