### PR TITLE
@Consumption.aiHint — AI hint term in Consumption vocabulary

### DIFF
--- a/vocabularies/Consumption.json
+++ b/vocabularies/Consumption.json
@@ -1,0 +1,31 @@
+{
+  "$Version": "4.0",
+  "$Reference": {
+    "https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.json": {
+      "$Include": [{ "$Namespace": "Org.OData.Core.V1", "$Alias": "Core" }]
+    },
+    "https://sap.github.io/odata-vocabularies/vocabularies/Common.json": {
+      "$Include": [{ "$Namespace": "com.sap.vocabularies.Common.v1", "$Alias": "Common" }]
+    }
+  },
+  "com.sap.vocabularies.Consumption.v1": {
+    "$Alias": "Consumption",
+    "@Core.Description": "Terms for consumption metadata",
+    "@Core.Description#Published": "2026-07-24 © Copyright 2026 SAP SE. All rights reserved",
+    "@Core.Links": [
+      { "rel": "alternate", "href": "https://sap.github.io/odata-vocabularies/vocabularies/Consumption.xml" },
+      { "rel": "latest-version", "href": "https://sap.github.io/odata-vocabularies/vocabularies/Consumption.json" },
+      {
+        "rel": "describedby",
+        "href": "https://github.com/sap/odata-vocabularies/blob/main/vocabularies/Consumption.md"
+      }
+    ],
+    "aiHint": {
+      "$Kind": "Term",
+      "$AppliesTo": ["EntityType", "EntitySet", "NavigationProperty", "Property", "EntityContainer", "TypeDefinition"],
+      "@Common.Experimental": true,
+      "@Core.Description": "A free-text hint for AI consumers (e.g., large language models or AI agents) on how to use or interpret the annotated element.",
+      "@Core.LongDescription": "Provides guidance for AI consumers (e.g., LLMs or AI agents) on how to use or interpret the annotated OData element.\nIt is intentionally kept separate from human-readable descriptions (e.g., Core.Description)\nso that end-user-facing documentation and AI-targeted guidance can evolve independently.\n\nThe annotation value is a plain string, optionally formatted using lightweight Markdown\n(bold labels, bullet points, inline code). Typical content includes:\n\n* Business context: what business concept or domain object the element represents\n* Usage guidance: when and how to use this entity, property, or service\n* Disambiguation: how to distinguish from similar entities or operations\n* Value constraints: valid values, formats, coding standards (e.g., ISO codes, enums)\n* Authorization: required scopes or roles for write operations (service level)\n* Routing guidance: when NOT to use this element and what to use instead\n\nThe annotation value MUST NOT be displayed to end users and MUST be filtered\nwhen publishing metadata externally (e.g., to public API catalogs).\n\nThe corresponding annotation in ABAP CDS / CSN Interop is @Consumption.aiHint.\nIn JSON Schema-based formats (OpenAPI, AsyncAPI), the equivalent is x-sap-ai-hint.\n          "
+    }
+  }
+}

--- a/vocabularies/Consumption.md
+++ b/vocabularies/Consumption.md
@@ -1,0 +1,11 @@
+# Consumption Vocabulary
+**Namespace: [com.sap.vocabularies.Consumption.v1](Consumption.xml)**
+
+Terms for consumption metadata
+
+
+## Terms
+
+Term|Type|Description
+:---|:---|:----------
+[aiHint](Consumption.xml#L35) *([Experimental](Common.md#Experimental))*|String|<a name="aiHint"></a>A free-text hint for AI consumers (e.g., large language models or AI agents) on how to use or interpret the annotated element.<br><p>Provides guidance for AI consumers (e.g., LLMs or AI agents) on how to use or interpret the annotated OData element. It is intentionally kept separate from human-readable descriptions (e.g., Core.Description) so that end-user-facing documentation and AI-targeted guidance can evolve independently.</p> <p>The annotation value is a plain string, optionally formatted using lightweight Markdown (bold labels, bullet points, inline code). Typical content includes:</p> <ul> <li>Business context: what business concept or domain object the element represents</li> <li>Usage guidance: when and how to use this entity, property, or service</li> <li>Disambiguation: how to distinguish from similar entities or operations</li> <li>Value constraints: valid values, formats, coding standards (e.g., ISO codes, enums)</li> <li>Authorization: required scopes or roles for write operations (service level)</li> <li>Routing guidance: when NOT to use this element and what to use instead</li> </ul> <p>The annotation value MUST NOT be displayed to end users and MUST be filtered when publishing metadata externally (e.g., to public API catalogs).</p> <p>The corresponding annotation in ABAP CDS / CSN Interop is @Consumption.aiHint. In JSON Schema-based formats (OpenAPI, AsyncAPI), the equivalent is x-sap-ai-hint.</p> 

--- a/vocabularies/Consumption.xml
+++ b/vocabularies/Consumption.xml
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="utf-8"?>
+<edmx:Edmx xmlns:edmx="http://docs.oasis-open.org/odata/ns/edmx" Version="4.0">
+  <edmx:Reference Uri="https://oasis-tcs.github.io/odata-vocabularies/vocabularies/Org.OData.Core.V1.xml">
+    <edmx:Include Alias="Core" Namespace="Org.OData.Core.V1" />
+  </edmx:Reference>
+  <edmx:Reference Uri="https://sap.github.io/odata-vocabularies/vocabularies/Common.xml">
+    <edmx:Include Namespace="com.sap.vocabularies.Common.v1" Alias="Common" />
+  </edmx:Reference>
+
+  <edmx:DataServices>
+    <Schema xmlns="http://docs.oasis-open.org/odata/ns/edm" Namespace="com.sap.vocabularies.Consumption.v1" Alias="Consumption">
+      <Annotation Term="Core.Description">
+        <String>Terms for consumption metadata</String>
+      </Annotation>
+      <Annotation Term="Core.Description" Qualifier="Published">
+        <String>2026-07-24 © Copyright 2026 SAP SE. All rights reserved</String>
+      </Annotation>
+      <Annotation Term="Core.Links">
+        <Collection>
+          <Record>
+            <PropertyValue Property="rel" String="latest-version" />
+            <PropertyValue Property="href" String="https://sap.github.io/odata-vocabularies/vocabularies/Consumption.xml" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="alternate" />
+            <PropertyValue Property="href" String="https://sap.github.io/odata-vocabularies/vocabularies/Consumption.json" />
+          </Record>
+          <Record>
+            <PropertyValue Property="rel" String="describedby" />
+            <PropertyValue Property="href" String="https://github.com/sap/odata-vocabularies/blob/main/vocabularies/Consumption.md" />
+          </Record>
+        </Collection>
+      </Annotation>
+
+      <Term Name="aiHint" Type="Edm.String" Nullable="false" AppliesTo="EntityType EntitySet NavigationProperty Property EntityContainer TypeDefinition">
+        <Annotation Term="Common.Experimental" />
+        <Annotation Term="Core.Description">
+          <String>A free-text hint for AI consumers (e.g., large language models or AI agents) on how to use or interpret the annotated element.</String>
+        </Annotation>
+        <Annotation Term="Core.LongDescription">
+          <String>Provides guidance for AI consumers (e.g., LLMs or AI agents) on how to use or interpret the annotated OData element.
+It is intentionally kept separate from human-readable descriptions (e.g., Core.Description)
+so that end-user-facing documentation and AI-targeted guidance can evolve independently.
+
+The annotation value is a plain string, optionally formatted using lightweight Markdown
+(bold labels, bullet points, inline code). Typical content includes:
+
+* Business context: what business concept or domain object the element represents
+* Usage guidance: when and how to use this entity, property, or service
+* Disambiguation: how to distinguish from similar entities or operations
+* Value constraints: valid values, formats, coding standards (e.g., ISO codes, enums)
+* Authorization: required scopes or roles for write operations (service level)
+* Routing guidance: when NOT to use this element and what to use instead
+
+The annotation value MUST NOT be displayed to end users and MUST be filtered
+when publishing metadata externally (e.g., to public API catalogs).
+
+The corresponding annotation in ABAP CDS / CSN Interop is @Consumption.aiHint.
+In JSON Schema-based formats (OpenAPI, AsyncAPI), the equivalent is x-sap-ai-hint.
+          </String>
+        </Annotation>
+      </Term>
+    </Schema>
+  </edmx:DataServices>
+</edmx:Edmx>


### PR DESCRIPTION
## Summary

Adds `@Consumption.aiHint` to a new `Consumption` vocabulary, providing a free-text hint for AI consumers (LLMs, agents) on how to use or interpret an annotated OData element.

### Changes

- New vocabulary `com.sap.vocabularies.Consumption.v1` with term `aiHint`
- Term is marked `@Common.Experimental`
- Applies to: EntityType, EntitySet, NavigationProperty, Property, EntityContainer, TypeDefinition

### Cross-format alignment

This aligns the OData annotation name with the other SAP metadata formats:

| Format | Annotation / Property |
|---|---|
| **OData** | `@Consumption.aiHint` ← this PR |
| **CSN Interop / ABAP CDS** | `@Consumption.aiHint` ([SAP/csn-interop-specification#186](https://github.com/SAP/csn-interop-specification/pull/186)) |
| OpenAPI / AsyncAPI / JSON Schema | `x-sap-ai-hint` |

### Replaces

This replaces #440 (`@AI.hint` in a separate AI vocabulary). Using the `Consumption` namespace aligns with the CSN Interop decision (PR #186) and avoids a separate vocabulary just for one term.

The key design argument for a dedicated annotation (vs. a qualified `Core.Description`): AI-targeted guidance and human-readable descriptions must evolve independently, and the annotation value MUST NOT be surfaced to end users. A qualified description does not carry that semantic contract.